### PR TITLE
fix for queries with both order by and limit

### DIFF
--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -1166,23 +1166,20 @@ impl Parser {
             // look for optional ASC / DESC specifier
             let asc = match self.peek_token() {
                 Some(Token::Keyword(k)) => {
-                    self.next_token(); // consume it
                     match k.to_uppercase().as_ref() {
-                        "ASC" => true,
-                        "DESC" => false,
-                        _ => {
-                            return parser_err!(format!(
-                                "Invalid modifier for ORDER BY expression: {:?}",
-                                k
-                            ))
-                        }
+                        "ASC" => {
+                            self.next_token();
+                            true
+                        },
+                        "DESC" => {
+                            self.next_token();
+                            false
+                        },
+                        _ => true
                     }
                 }
                 Some(Token::Comma) => true,
-                Some(other) => {
-                    return parser_err!(format!("Unexpected token after ORDER BY expr: {:?}", other))
-                }
-                None => true,
+                _ => true,
             };
 
             expr_list.push(SQLOrderByExpr::new(Box::new(expr), asc));

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -201,6 +201,33 @@ fn parse_select_order_by() {
 }
 
 #[test]
+fn parse_select_order_by_limit() {
+    let sql = String::from(
+        "SELECT id, fname, lname FROM customer WHERE id < 5 ORDER BY lname ASC, fname DESC LIMIT 2",
+    );
+    let ast = parse_sql(&sql);
+    match ast {
+        ASTNode::SQLSelect { order_by, limit, .. } => {
+            assert_eq!(
+                Some(vec![
+                    SQLOrderByExpr {
+                        expr: Box::new(ASTNode::SQLIdentifier("lname".to_string())),
+                        asc: true,
+                    },
+                    SQLOrderByExpr {
+                        expr: Box::new(ASTNode::SQLIdentifier("fname".to_string())),
+                        asc: false,
+                    },
+                ]),
+                order_by
+            );
+            assert_eq!(Some(Box::new(ASTNode::SQLValue(Value::Long(2)))), limit);
+        }
+        _ => assert!(false),
+    }
+}
+
+#[test]
 fn parse_select_group_by() {
     let sql = String::from("SELECT id, fname, lname FROM customer GROUP BY lname, fname");
     let ast = parse_sql(&sql);


### PR DESCRIPTION
This PR adds support for queries like:
`SELECT col_name FROM table_name WHERE id <= 100 ORDER BY date_reg LIMIT 5`