### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -95,15 +95,7 @@ impl Parser {
                     "INSERT" => Ok(self.parse_insert()?),
                     "ALTER" => Ok(self.parse_alter()?),
                     "COPY" => Ok(self.parse_copy()?),
-                    "TRUE" => {
-                        self.prev_token();
-                        self.parse_sql_value()
-                    }
-                    "FALSE" => {
-                        self.prev_token();
-                        self.parse_sql_value()
-                    }
-                    "NULL" => {
+                    "TRUE" | "FALSE" | "NULL" => {
                         self.prev_token();
                         self.parse_sql_value()
                     }
@@ -136,19 +128,10 @@ impl Parser {
                         }
                     }
                 }
-                Token::Number(_) => {
-                    self.prev_token();
-                    self.parse_sql_value()
-                }
-                Token::String(_) => {
-                    self.prev_token();
-                    self.parse_sql_value()
-                }
-                Token::SingleQuotedString(_) => {
-                    self.prev_token();
-                    self.parse_sql_value()
-                }
-                Token::DoubleQuotedString(_) => {
+                Token::Number(_)
+                | Token::String(_)
+                | Token::SingleQuotedString(_)
+                | Token::DoubleQuotedString(_) => {
                     self.prev_token();
                     self.parse_sql_value()
                 }

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -345,11 +345,17 @@ impl Parser {
         }
     }
 
+    /// Return first non-whitespace token that has not yet been processed
     pub fn peek_token(&self) -> Option<Token> {
-        self.peek_token_skip_whitespace()
+        if let Some(n) = self.til_non_whitespace() {
+            self.token_at(n)
+        } else {
+            None
+        }
     }
 
-    pub fn skip_whitespace(&mut self) -> Option<Token> {
+    /// Get the next token skipping whitespace and increment the token index
+    pub fn next_token(&mut self) -> Option<Token> {
         loop {
             match self.next_token_no_skip() {
                 Some(Token::Whitespace(_)) => {
@@ -389,19 +395,6 @@ impl Parser {
         }
     }
 
-    pub fn peek_token_skip_whitespace(&self) -> Option<Token> {
-        if let Some(n) = self.til_non_whitespace() {
-            self.token_at(n)
-        } else {
-            None
-        }
-    }
-
-    /// Get the next token skipping whitespace and increment the token index
-    pub fn next_token(&mut self) -> Option<Token> {
-        self.skip_whitespace()
-    }
-
     pub fn next_token_no_skip(&mut self) -> Option<Token> {
         if self.index < self.tokens.len() {
             self.index = self.index + 1;
@@ -411,9 +404,9 @@ impl Parser {
         }
     }
 
-    /// if prev token is whitespace skip it
-    /// if prev token is not whitespace skipt it as well
-    pub fn prev_token_skip_whitespace(&mut self) -> Option<Token> {
+    /// Push back the last one non-whitespace token
+    pub fn prev_token(&mut self) -> Option<Token> {
+        // TODO: returned value is unused (available via peek_token)
         loop {
             match self.prev_token_no_skip() {
                 Some(Token::Whitespace(_)) => {
@@ -426,12 +419,8 @@ impl Parser {
         }
     }
 
-    pub fn prev_token(&mut self) -> Option<Token> {
-        self.prev_token_skip_whitespace()
-    }
-
     /// Get the previous token and decrement the token index
-    pub fn prev_token_no_skip(&mut self) -> Option<Token> {
+    fn prev_token_no_skip(&mut self) -> Option<Token> {
         if self.index > 0 {
             self.index = self.index - 1;
             Some(self.tokens[self.index].clone())

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -227,16 +227,10 @@ impl Parser {
     /// Parse a postgresql casting style which is in the form of `expr::datatype`
     pub fn parse_pg_cast(&mut self, expr: ASTNode) -> Result<ASTNode, ParserError> {
         let _ = self.consume_token(&Token::DoubleColon)?;
-        let datatype = self.parse_data_type()?;
-        let pg_cast = ASTNode::SQLCast {
+        Ok(ASTNode::SQLCast {
             expr: Box::new(expr),
-            data_type: datatype,
-        };
-        if let Some(Token::DoubleColon) = self.peek_token() {
-            self.parse_pg_cast(pg_cast)
-        } else {
-            Ok(pg_cast)
-        }
+            data_type: self.parse_data_type()?,
+        })
     }
 
     /// Parse an expression infix (typically an operator)

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -108,7 +108,7 @@ impl Parser {
                         self.parse_cast_expression()
                     } else {
                         match self.peek_token() {
-                            Some(Token::LParen) => self.parse_function_or_pg_cast(&id),
+                            Some(Token::LParen) => self.parse_function(&id),
                             Some(Token::Period) => {
                                 let mut id_parts: Vec<String> = vec![id];
                                 while self.peek_token() == Some(Token::Period) {
@@ -148,15 +148,6 @@ impl Parser {
                 )),
             },
             None => parser_err!(format!("Prefix parser expected a keyword but hit EOF")),
-        }
-    }
-
-    pub fn parse_function_or_pg_cast(&mut self, id: &str) -> Result<ASTNode, ParserError> {
-        let func = self.parse_function(&id)?;
-        if let Some(Token::DoubleColon) = self.peek_token() {
-            self.parse_pg_cast(func)
-        } else {
-            Ok(func)
         }
     }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -657,6 +657,7 @@ fn parse_timestamps_example() {
     let sql = "2016-02-15 09:43:33";
     let _ = parse_sql(sql);
     //TODO add assertion
+    //assert_eq!(sql, ast.to_string());
 }
 
 #[test]
@@ -664,6 +665,7 @@ fn parse_timestamps_with_millis_example() {
     let sql = "2017-11-02 19:15:42.308637";
     let _ = parse_sql(sql);
     //TODO add assertion
+    //assert_eq!(sql, ast.to_string());
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -532,6 +532,20 @@ fn parse_create_table_from_pg_dump() {
             assert_eq!(SQLType::Varchar(Some(45)), c_first_name.data_type);
             assert_eq!(false, c_first_name.allow_null);
 
+            let c_create_date1 = &columns[8];
+            assert_eq!(
+                Some(Box::new(ASTNode::SQLCast {
+                    expr: Box::new(ASTNode::SQLCast {
+                        expr: Box::new(ASTNode::SQLValue(Value::SingleQuotedString(
+                            "now".to_string()
+                        ))),
+                        data_type: SQLType::Text
+                    }),
+                    data_type: SQLType::Date
+                })),
+                c_create_date1.default
+            );
+
             let c_release_year = &columns[10];
             assert_eq!(
                 SQLType::Custom("public.year".to_string()),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -517,20 +517,26 @@ fn parse_create_table_from_pg_dump() {
         ASTNode::SQLCreateTable { name, columns } => {
             assert_eq!("public.customer", name);
 
-            let c_name = &columns[0];
-            assert_eq!("customer_id", c_name.name);
-            assert_eq!(SQLType::Int, c_name.data_type);
-            assert_eq!(false, c_name.allow_null);
+            let c_customer_id = &columns[0];
+            assert_eq!("customer_id", c_customer_id.name);
+            assert_eq!(SQLType::Int, c_customer_id.data_type);
+            assert_eq!(false, c_customer_id.allow_null);
 
-            let c_lat = &columns[1];
-            assert_eq!("store_id", c_lat.name);
-            assert_eq!(SQLType::SmallInt, c_lat.data_type);
-            assert_eq!(false, c_lat.allow_null);
+            let c_store_id = &columns[1];
+            assert_eq!("store_id", c_store_id.name);
+            assert_eq!(SQLType::SmallInt, c_store_id.data_type);
+            assert_eq!(false, c_store_id.allow_null);
 
-            let c_lng = &columns[2];
-            assert_eq!("first_name", c_lng.name);
-            assert_eq!(SQLType::Varchar(Some(45)), c_lng.data_type);
-            assert_eq!(false, c_lng.allow_null);
+            let c_first_name = &columns[2];
+            assert_eq!("first_name", c_first_name.name);
+            assert_eq!(SQLType::Varchar(Some(45)), c_first_name.data_type);
+            assert_eq!(false, c_first_name.allow_null);
+
+            let c_release_year = &columns[10];
+            assert_eq!(
+                SQLType::Custom("public.year".to_string()),
+                c_release_year.data_type
+            );
         }
         _ => assert!(false),
     }


### PR DESCRIPTION
These are a few unrelated fixes I came up with while reading through the code. See the commit messages for more details about each one.

I added tests where there wasn't sufficient coverage, except for timestamps where the code being fixed is effectively unused at this moment, since we don't have the code to handle `TIMESTAMP '...'` literals.