### PR TITLE
Support parsing table & column aliases.

### DIFF
--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -40,6 +40,11 @@ pub enum ASTNode {
     SQLIsNull(Box<ASTNode>),
     /// `IS NOT NULL` expression
     SQLIsNotNull(Box<ASTNode>),
+    /// Column projection with alias.
+    SQLProjectionExpr {
+        column_name: Box<ASTNode>,
+        alias: Option<String>
+    },
     /// Binary expression e.g. `1 + 1` or `foo > bar`
     SQLBinaryExpr {
         left: Box<ASTNode>,
@@ -145,6 +150,12 @@ impl ToString for ASTNode {
             ASTNode::SQLAssignment(ass) => ass.to_string(),
             ASTNode::SQLIsNull(ast) => format!("{} IS NULL", ast.as_ref().to_string()),
             ASTNode::SQLIsNotNull(ast) => format!("{} IS NOT NULL", ast.as_ref().to_string()),
+            ASTNode::SQLProjectionExpr { column_name, alias} => {
+                match alias {
+                    Some(alias) => format!("{} AS {}", column_name.to_string(), alias),
+                    None => column_name.to_string()
+                }
+            }
             ASTNode::SQLBinaryExpr { left, op, right } => format!(
                 "{} {} {}",
                 left.as_ref().to_string(),

--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -40,8 +40,8 @@ pub enum ASTNode {
     SQLIsNull(Box<ASTNode>),
     /// `IS NOT NULL` expression
     SQLIsNotNull(Box<ASTNode>),
-    /// Column projection with alias.
-    SQLProjectionExpr {
+    /// Column/Table name with alias.
+    SQLNameAliasExpr {
         column_name: Box<ASTNode>,
         alias: Option<String>
     },
@@ -150,7 +150,7 @@ impl ToString for ASTNode {
             ASTNode::SQLAssignment(ass) => ass.to_string(),
             ASTNode::SQLIsNull(ast) => format!("{} IS NULL", ast.as_ref().to_string()),
             ASTNode::SQLIsNotNull(ast) => format!("{} IS NOT NULL", ast.as_ref().to_string()),
-            ASTNode::SQLProjectionExpr { column_name, alias} => {
+            ASTNode::SQLNameAliasExpr { column_name, alias} => {
                 match alias {
                     Some(alias) => format!("{} AS {}", column_name.to_string(), alias),
                     None => column_name.to_string()

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -116,6 +116,16 @@ fn parse_as() {
 }
 
 #[test]
+fn parse_table_as() {
+    let sql = String::from(
+        "SELECT c.id as ID FROM customer AS c",
+    );
+    let _ast = parse_sql(&sql);
+
+    //TODO: add assertions
+}
+
+#[test]
 fn parse_not() {
     let sql = String::from(
         "SELECT id FROM customer \
@@ -395,7 +405,7 @@ fn parse_select_version() {
         ASTNode::SQLSelect { ref projection, .. } => {
             assert_eq!(
                 projection[0],
-                ASTNode::SQLProjectionExpr {
+                ASTNode::SQLNameAliasExpr {
                     column_name: Box::new(ASTNode::SQLIdentifier("@@version".to_string())),
                     alias: None
                 }

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -106,6 +106,16 @@ fn parse_select_count_wildcard() {
 }
 
 #[test]
+fn parse_as() {
+    let sql = String::from(
+        "SELECT id as ID FROM customer",
+    );
+    let _ast = parse_sql(&sql);
+
+    //TODO: add assertions
+}
+
+#[test]
 fn parse_not() {
     let sql = String::from(
         "SELECT id FROM customer \
@@ -385,7 +395,10 @@ fn parse_select_version() {
         ASTNode::SQLSelect { ref projection, .. } => {
             assert_eq!(
                 projection[0],
-                ASTNode::SQLIdentifier("@@version".to_string())
+                ASTNode::SQLProjectionExpr {
+                    column_name: Box::new(ASTNode::SQLIdentifier("@@version".to_string())),
+                    alias: None
+                }
             );
         }
         _ => panic!(),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -735,7 +735,7 @@ fn parse_select_version() {
         ASTNode::SQLSelect { ref projection, .. } => {
             assert_eq!(
                 projection[0],
-                ASTNode::SQLProjectionExpr {
+                ASTNode::SQLNameAliasExpr {
                     column_name: Box::new(ASTNode::SQLIdentifier("@@version".to_string())),
                     alias: None
                 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -735,7 +735,10 @@ fn parse_select_version() {
         ASTNode::SQLSelect { ref projection, .. } => {
             assert_eq!(
                 projection[0],
-                ASTNode::SQLIdentifier("@@version".to_string())
+                ASTNode::SQLProjectionExpr {
+                    column_name: Box::new(ASTNode::SQLIdentifier("@@version".to_string())),
+                    alias: None
+                }
             );
         }
         _ => panic!(),


### PR DESCRIPTION
This PR add the support of table & column aliases.
The following SQL now can be parsed w/o error.
```SQL
SELECT c.id as ID FROM customer AS c
```


The `SQLNameAliasExpr` will change the usage. So it should be a new version of this modification.