### PR TITLE
Support SELECT DISTINCT, and a few minor tweaks

### DIFF
--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -110,6 +110,7 @@ impl ToString for SQLSetOperator {
 /// to a set operation like `UNION`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SQLSelect {
+    pub distinct: bool,
     /// projection expressions
     pub projection: Vec<SQLSelectItem>,
     /// FROM
@@ -127,7 +128,8 @@ pub struct SQLSelect {
 impl ToString for SQLSelect {
     fn to_string(&self) -> String {
         let mut s = format!(
-            "SELECT {}",
+            "SELECT{} {}",
+            if self.distinct { " DISTINCT" } else { "" },
             self.projection
                 .iter()
                 .map(|p| p.to_string())

--- a/src/sqlast/sql_operator.rs
+++ b/src/sqlast/sql_operator.rs
@@ -1,5 +1,5 @@
 /// SQL Operator
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SQLOperator {
     Plus,
     Minus,

--- a/src/sqlast/sqltype.rs
+++ b/src/sqlast/sqltype.rs
@@ -76,12 +76,10 @@ impl ToString for SQLType {
             SQLType::Decimal(precision, scale) => {
                 if let Some(scale) = scale {
                     format!("numeric({},{})", precision.unwrap(), scale)
+                } else if let Some(precision) = precision {
+                    format!("numeric({})", precision)
                 } else {
-                    if let Some(precision) = precision {
-                        format!("numeric({})", precision)
-                    } else {
-                        format!("numeric")
-                    }
+                    format!("numeric")
                 }
             }
             SQLType::SmallInt => "smallint".to_string(),

--- a/src/sqlast/table_key.rs
+++ b/src/sqlast/table_key.rs
@@ -1,6 +1,6 @@
 use super::{SQLIdent, SQLObjectName};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AlterOperation {
     AddConstraint(TableKey),
     RemoveConstraint { name: SQLIdent },
@@ -17,13 +17,13 @@ impl ToString for AlterOperation {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Key {
     pub name: SQLIdent,
     pub columns: Vec<SQLIdent>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TableKey {
     PrimaryKey(Key),
     UniqueKey(Key),

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -326,7 +326,7 @@ impl Parser {
                         })
                     } else {
                         parser_err!(format!(
-                            "Expected IN or LIKE after NOT, found {:?}",
+                            "Expected BETWEEN, IN or LIKE after NOT, found {:?}",
                             self.peek_token()
                         ))
                     }

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -1352,6 +1352,7 @@ impl Parser {
     /// Parse a restricted `SELECT` statement (no CTEs / `UNION` / `ORDER BY`),
     /// assuming the initial `SELECT` was already consumed
     pub fn parse_select(&mut self) -> Result<SQLSelect, ParserError> {
+        let distinct = self.parse_keyword("DISTINCT");
         let projection = self.parse_select_list()?;
 
         let (relation, joins) = if self.parse_keyword("FROM") {
@@ -1381,6 +1382,7 @@ impl Parser {
         };
 
         Ok(SQLSelect {
+            distinct,
             projection,
             selection,
             relation,

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -239,16 +239,14 @@ impl Parser {
 
     pub fn parse_function(&mut self, id: SQLIdent) -> Result<ASTNode, ParserError> {
         self.expect_token(&Token::LParen)?;
-        if self.consume_token(&Token::RParen) {
-            Ok(ASTNode::SQLFunction {
-                id: id,
-                args: vec![],
-            })
+        let args = if self.consume_token(&Token::RParen) {
+            vec![]
         } else {
             let args = self.parse_expr_list()?;
             self.expect_token(&Token::RParen)?;
-            Ok(ASTNode::SQLFunction { id, args })
-        }
+            args
+        };
+        Ok(ASTNode::SQLFunction { id, args })
     }
 
     pub fn parse_case_expression(&mut self) -> Result<ASTNode, ParserError> {

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -50,9 +50,21 @@ fn parse_where_delete_statement() {
 fn parse_simple_select() {
     let sql = "SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5";
     let select = verified_only_select(sql);
+    assert_eq!(false, select.distinct);
     assert_eq!(3, select.projection.len());
     let select = verified_query(sql);
     assert_eq!(Some(ASTNode::SQLValue(Value::Long(5))), select.limit);
+}
+
+#[test]
+fn parse_select_distinct() {
+    let sql = "SELECT DISTINCT name FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(true, select.distinct);
+    assert_eq!(
+        &SQLSelectItem::UnnamedExpression(ASTNode::SQLIdentifier("name".to_string())),
+        only(&select.projection)
+    );
 }
 
 #[test]


### PR DESCRIPTION
The grammar [describes](https://jakewheat.github.io/sql-overview/sql-2011-foundation-grammar.html#query-specification) this as:

        <query specification> ::=
            SELECT [ <set quantifier> ] <select list> <table expression>

        <set quantifier> ::=
            DISTINCT
          | ALL

I've chosen not to add `ALL`, as it's equivalent to omitting the quantifier and I have not ever seen it used in practice (I'm also afraid that some dialects might allow ALL as a column name).

(I've also included some minor unrelated changes as separate commits in this PR.)