### PR TITLE
Rust 2018 and clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ uuid = "0.7.1"
 
 [dev-dependencies]
 simple_logger = "1.0.1"
+matches = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ include = [
     "src/**/*.rs",
     "Cargo.toml",
 ]
+edition = "2018"
 
 [lib]
 name = "sqlparser"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,5 +1,5 @@
-extern crate simple_logger;
-extern crate sqlparser;
+use simple_logger;
+
 ///! A small command-line app to run the parser.
 /// Run with `cargo run --example cli`
 use std::fs;

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 use simple_logger;
 
 ///! A small command-line app to run the parser.

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -14,8 +14,8 @@ fn main() {
         .nth(1)
         .expect("No arguments provided!\n\nUsage: cargo run --example cli FILENAME.sql");
 
-    let contents =
-        fs::read_to_string(&filename).expect(&format!("Unable to read the file {}", &filename));
+    let contents = fs::read_to_string(&filename)
+        .unwrap_or_else(|_| panic!("Unable to read the file {}", &filename));
     let without_bom = if contents.chars().nth(0).unwrap() as u64 != 0xfeff {
         contents.as_str()
     } else {
@@ -31,7 +31,7 @@ fn main() {
                 "Round-trip:\n'{}'",
                 statements
                     .iter()
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
                     .collect::<Vec<_>>()
                     .join("\n")
             );

--- a/examples/parse_select.rs
+++ b/examples/parse_select.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 use sqlparser::dialect::GenericSqlDialect;
 use sqlparser::sqlparser::*;
 

--- a/examples/parse_select.rs
+++ b/examples/parse_select.rs
@@ -1,5 +1,3 @@
-extern crate sqlparser;
-
 use sqlparser::dialect::GenericSqlDialect;
 use sqlparser::sqlparser::*;
 

--- a/src/dialect/ansi_sql.rs
+++ b/src/dialect/ansi_sql.rs
@@ -1,4 +1,4 @@
-use dialect::Dialect;
+use crate::dialect::Dialect;
 
 pub struct AnsiSqlDialect {}
 

--- a/src/dialect/generic_sql.rs
+++ b/src/dialect/generic_sql.rs
@@ -1,4 +1,4 @@
-use dialect::Dialect;
+use crate::dialect::Dialect;
 pub struct GenericSqlDialect {}
 
 impl Dialect for GenericSqlDialect {

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -365,9 +365,9 @@ keyword!(
 );
 
 /// special case of keyword where the it is an invalid identifier
-pub const END_EXEC: &'static str = "END-EXEC";
+pub const END_EXEC: &str = "END-EXEC";
 
-pub const ALL_KEYWORDS: &'static [&'static str] = &[
+pub const ALL_KEYWORDS: &[&str] = &[
     ABS,
     ADD,
     ASC,
@@ -716,7 +716,7 @@ pub const ALL_KEYWORDS: &'static [&'static str] = &[
 
 /// These keywords can't be used as a table alias, so that `FROM table_name alias`
 /// can be parsed unambiguously without looking ahead.
-pub const RESERVED_FOR_TABLE_ALIAS: &'static [&'static str] = &[
+pub const RESERVED_FOR_TABLE_ALIAS: &[&str] = &[
     // Reserved as both a table and a column alias:
     WITH, SELECT, WHERE, GROUP, ORDER, UNION, EXCEPT, INTERSECT,
     // Reserved only as a table alias in the `FROM`/`JOIN` clauses:
@@ -725,7 +725,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &'static [&'static str] = &[
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`
 /// can be parsed unambiguously without looking ahead.
-pub const RESERVED_FOR_COLUMN_ALIAS: &'static [&'static str] = &[
+pub const RESERVED_FOR_COLUMN_ALIAS: &[&str] = &[
     // Reserved as both a table and a column alias:
     WITH, SELECT, WHERE, GROUP, ORDER, UNION, EXCEPT, INTERSECT,
     // Reserved only as a column alias in the `SELECT` clause:

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -1,4 +1,4 @@
-use dialect::Dialect;
+use crate::dialect::Dialect;
 
 pub struct PostgreSqlDialect {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //!
 //! println!("AST: {:?}", ast);
 //! ```
+#![warn(clippy::all)]
 
 pub mod dialect;
 pub mod sqlast;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,6 @@
 //! println!("AST: {:?}", ast);
 //! ```
 
-#[macro_use]
-extern crate log;
-extern crate chrono;
-extern crate uuid;
-
 pub mod dialect;
 pub mod sqlast;
 pub mod sqlparser;

--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -483,7 +483,7 @@ impl ToString for FileFormat {
     }
 }
 
-use sqlparser::ParserError;
+use crate::sqlparser::ParserError;
 use std::str::FromStr;
 impl FromStr for FileFormat {
     type Err = ParserError;

--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -202,7 +202,7 @@ impl ToString for ASTNode {
 #[derive(Debug, Clone, PartialEq)]
 pub enum SQLStatement {
     /// SELECT
-    SQLSelect(SQLQuery),
+    SQLQuery(Box<SQLQuery>),
     /// INSERT
     SQLInsert {
         /// TABLE
@@ -240,7 +240,7 @@ pub enum SQLStatement {
     SQLCreateView {
         /// View name
         name: SQLObjectName,
-        query: SQLQuery,
+        query: Box<SQLQuery>,
         materialized: bool,
     },
     /// CREATE TABLE
@@ -264,7 +264,7 @@ pub enum SQLStatement {
 impl ToString for SQLStatement {
     fn to_string(&self) -> String {
         match self {
-            SQLStatement::SQLSelect(s) => s.to_string(),
+            SQLStatement::SQLQuery(s) => s.to_string(),
             SQLStatement::SQLInsert {
                 table_name,
                 columns,

--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -271,10 +271,10 @@ impl ToString for SQLStatement {
                 values,
             } => {
                 let mut s = format!("INSERT INTO {}", table_name.to_string());
-                if columns.len() > 0 {
+                if !columns.is_empty() {
                     s += &format!(" ({})", columns.join(", "));
                 }
-                if values.len() > 0 {
+                if !values.is_empty() {
                     s += &format!(
                         " VALUES({})",
                         values
@@ -307,12 +307,12 @@ impl ToString for SQLStatement {
                     );
                 }
                 s += " FROM stdin; ";
-                if values.len() > 0 {
+                if !values.is_empty() {
                     s += &format!(
                         "\n{}",
                         values
                             .iter()
-                            .map(|v| v.clone().unwrap_or("\\N".to_string()))
+                            .map(|v| v.clone().unwrap_or_else(|| "\\N".to_string()))
                             .collect::<Vec<String>>()
                             .join("\t")
                     );
@@ -381,13 +381,7 @@ impl ToString for SQLStatement {
                 file_format.as_ref().map(|f| f.to_string()).unwrap(),
                 location.as_ref().unwrap()
             ),
-            SQLStatement::SQLCreateTable {
-                name,
-                columns,
-                external: _,
-                file_format: _,
-                location: _,
-            } => format!(
+            SQLStatement::SQLCreateTable { name, columns, .. } => format!(
                 "CREATE TABLE {} ({})",
                 name.to_string(),
                 columns

--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -50,7 +50,7 @@ impl ToString for SQLQuery {
 #[derive(Debug, Clone, PartialEq)]
 pub enum SQLSetExpr {
     /// Restricted SELECT .. FROM .. HAVING (no ORDER BY or set operations)
-    Select(SQLSelect),
+    Select(Box<SQLSelect>),
     /// Parenthesized SELECT subquery, which may include more set operations
     /// in its body and an optional ORDER BY / LIMIT.
     Query(Box<SQLQuery>),

--- a/src/sqlast/sqltype.rs
+++ b/src/sqlast/sqltype.rs
@@ -19,14 +19,14 @@ pub enum SQLType {
     Blob(usize),
     /// Decimal type with optional precision and scale e.g. DECIMAL(10,2)
     Decimal(Option<usize>, Option<usize>),
+    /// Floating point with optional precision e.g. FLOAT(8)
+    Float(Option<usize>),
     /// Small integer
     SmallInt,
     /// Integer
     Int,
     /// Big integer
     BigInt,
-    /// Floating point with optional precision e.g. FLOAT(8)
-    Float(Option<usize>),
     /// Floating point e.g. REAL
     Real,
     /// Double e.g. DOUBLE PRECISION
@@ -54,20 +54,8 @@ pub enum SQLType {
 impl ToString for SQLType {
     fn to_string(&self) -> String {
         match self {
-            SQLType::Char(size) => {
-                if let Some(size) = size {
-                    format!("char({})", size)
-                } else {
-                    "char".to_string()
-                }
-            }
-            SQLType::Varchar(size) => {
-                if let Some(size) = size {
-                    format!("character varying({})", size)
-                } else {
-                    "character varying".to_string()
-                }
-            }
+            SQLType::Char(size) => format_type_with_optional_length("char", size),
+            SQLType::Varchar(size) => format_type_with_optional_length("character varying", size),
             SQLType::Uuid => "uuid".to_string(),
             SQLType::Clob(size) => format!("clob({})", size),
             SQLType::Binary(size) => format!("binary({})", size),
@@ -76,22 +64,14 @@ impl ToString for SQLType {
             SQLType::Decimal(precision, scale) => {
                 if let Some(scale) = scale {
                     format!("numeric({},{})", precision.unwrap(), scale)
-                } else if let Some(precision) = precision {
-                    format!("numeric({})", precision)
                 } else {
-                    format!("numeric")
+                    format_type_with_optional_length("numeric", precision)
                 }
             }
+            SQLType::Float(size) => format_type_with_optional_length("float", size),
             SQLType::SmallInt => "smallint".to_string(),
             SQLType::Int => "int".to_string(),
             SQLType::BigInt => "bigint".to_string(),
-            SQLType::Float(size) => {
-                if let Some(size) = size {
-                    format!("float({})", size)
-                } else {
-                    "float".to_string()
-                }
-            }
             SQLType::Real => "real".to_string(),
             SQLType::Double => "double".to_string(),
             SQLType::Boolean => "boolean".to_string(),
@@ -105,4 +85,12 @@ impl ToString for SQLType {
             SQLType::Custom(ty) => ty.to_string(),
         }
     }
+}
+
+fn format_type_with_optional_length(sql_type: &str, len: &Option<usize>) -> String {
+    let mut s = sql_type.to_string();
+    if let Some(len) = len {
+        s += &format!("({})", len);
+    }
+    s
 }

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -56,7 +56,7 @@ impl Parser {
     }
 
     /// Parse a SQL statement and produce an Abstract Syntax Tree (AST)
-    pub fn parse_sql(dialect: &Dialect, sql: String) -> Result<Vec<SQLStatement>, ParserError> {
+    pub fn parse_sql(dialect: &dyn Dialect, sql: String) -> Result<Vec<SQLStatement>, ParserError> {
         let mut tokenizer = Tokenizer::new(dialect, &sql);
         let tokens = tokenizer.tokenize()?;
         let mut parser = Parser::new(tokens);

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -14,6 +14,8 @@
 
 //! SQL Parser
 
+use log::debug;
+
 use super::dialect::keywords;
 use super::dialect::Dialect;
 use super::sqlast::*;

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -703,9 +703,8 @@ impl Parser {
                     };
                     let allow_null = if self.parse_keywords(vec!["NOT", "NULL"]) {
                         false
-                    } else if self.parse_keyword("NULL") {
-                        true
                     } else {
+                        let _ = self.parse_keyword("NULL");
                         true
                     };
                     debug!("default: {:?}", default);
@@ -1016,11 +1015,8 @@ impl Parser {
                 "FLOAT" => Ok(SQLType::Float(self.parse_optional_precision()?)),
                 "REAL" => Ok(SQLType::Real),
                 "DOUBLE" => {
-                    if self.parse_keyword("PRECISION") {
-                        Ok(SQLType::Double)
-                    } else {
-                        Ok(SQLType::Double)
-                    }
+                    let _ = self.parse_keyword("PRECISION");
+                    Ok(SQLType::Double)
                 }
                 "SMALLINT" => Ok(SQLType::SmallInt),
                 "INT" | "INTEGER" => Ok(SQLType::Int),
@@ -1036,50 +1032,20 @@ impl Parser {
                 "UUID" => Ok(SQLType::Uuid),
                 "DATE" => Ok(SQLType::Date),
                 "TIMESTAMP" => {
-                    if self.parse_keyword("WITH") {
-                        if self.parse_keywords(vec!["TIME", "ZONE"]) {
-                            Ok(SQLType::Timestamp)
-                        } else {
-                            parser_err!(format!(
-                                "Expecting 'time zone', found: {:?}",
-                                self.peek_token()
-                            ))
-                        }
-                    } else if self.parse_keyword("WITHOUT") {
-                        if self.parse_keywords(vec!["TIME", "ZONE"]) {
-                            Ok(SQLType::Timestamp)
-                        } else {
-                            parser_err!(format!(
-                                "Expecting 'time zone', found: {:?}",
-                                self.peek_token()
-                            ))
-                        }
-                    } else {
-                        Ok(SQLType::Timestamp)
+                    // TBD: we throw away "with/without timezone" information
+                    if self.parse_keyword("WITH") || self.parse_keyword("WITHOUT") {
+                        self.expect_keyword("TIME")?;
+                        self.expect_keyword("ZONE")?;
                     }
+                    Ok(SQLType::Timestamp)
                 }
                 "TIME" => {
-                    if self.parse_keyword("WITH") {
-                        if self.parse_keywords(vec!["TIME", "ZONE"]) {
-                            Ok(SQLType::Time)
-                        } else {
-                            parser_err!(format!(
-                                "Expecting 'time zone', found: {:?}",
-                                self.peek_token()
-                            ))
-                        }
-                    } else if self.parse_keyword("WITHOUT") {
-                        if self.parse_keywords(vec!["TIME", "ZONE"]) {
-                            Ok(SQLType::Time)
-                        } else {
-                            parser_err!(format!(
-                                "Expecting 'time zone', found: {:?}",
-                                self.peek_token()
-                            ))
-                        }
-                    } else {
-                        Ok(SQLType::Timestamp)
+                    // TBD: we throw away "with/without timezone" information
+                    if self.parse_keyword("WITH") || self.parse_keyword("WITHOUT") {
+                        self.expect_keyword("TIME")?;
+                        self.expect_keyword("ZONE")?;
                     }
+                    Ok(SQLType::Time)
                 }
                 "REGCLASS" => Ok(SQLType::Regclass),
                 "TEXT" => {

--- a/src/sqltokenizer.rs
+++ b/src/sqltokenizer.rs
@@ -138,9 +138,9 @@ impl Token {
         let is_keyword = quote_style == None && ALL_KEYWORDS.contains(&word_uppercase.as_str());
         Token::SQLWord(SQLWord {
             value: word.to_string(),
-            quote_style: quote_style,
+            quote_style,
             keyword: if is_keyword {
-                word_uppercase.to_string()
+                word_uppercase
             } else {
                 "".to_string()
             },

--- a/src/sqltokenizer.rs
+++ b/src/sqltokenizer.rs
@@ -212,7 +212,7 @@ pub struct TokenizerError(String);
 
 /// SQL Tokenizer
 pub struct Tokenizer<'a> {
-    dialect: &'a Dialect,
+    dialect: &'a dyn Dialect,
     pub query: String,
     pub line: u64,
     pub col: u64,
@@ -220,7 +220,7 @@ pub struct Tokenizer<'a> {
 
 impl<'a> Tokenizer<'a> {
     /// Create a new SQL tokenizer for the specified SQL statement
-    pub fn new(dialect: &'a Dialect, query: &str) -> Self {
+    pub fn new(dialect: &'a dyn Dialect, query: &str) -> Self {
         Self {
             dialect,
             query: query.to_string(),
@@ -256,7 +256,7 @@ impl<'a> Tokenizer<'a> {
     }
 
     /// Get the next token or return None
-    fn next_token(&self, chars: &mut Peekable<Chars>) -> Result<Option<Token>, TokenizerError> {
+    fn next_token(&self, chars: &mut Peekable<Chars<'_>>) -> Result<Option<Token>, TokenizerError> {
         //println!("next_token: {:?}", chars.peek());
         match chars.peek() {
             Some(&ch) => match ch {
@@ -312,11 +312,11 @@ impl<'a> Tokenizer<'a> {
                     Ok(Some(Token::make_word(&s, Some(quote_start))))
                 }
                 // numbers
-                '0'...'9' => {
+                '0'..='9' => {
                     let mut s = String::new();
                     while let Some(&ch) = chars.peek() {
                         match ch {
-                            '0'...'9' | '.' => {
+                            '0'..='9' | '.' => {
                                 chars.next(); // consume
                                 s.push(ch);
                             }
@@ -436,7 +436,7 @@ impl<'a> Tokenizer<'a> {
     }
 
     /// Tokenize an identifier or keyword, after the first char is already consumed.
-    fn tokenize_word(&self, first_char: char, chars: &mut Peekable<Chars>) -> String {
+    fn tokenize_word(&self, first_char: char, chars: &mut Peekable<Chars<'_>>) -> String {
         let mut s = String::new();
         s.push(first_char);
         while let Some(&ch) = chars.peek() {
@@ -451,7 +451,7 @@ impl<'a> Tokenizer<'a> {
     }
 
     /// Read a single quoted string, starting with the opening quote.
-    fn tokenize_single_quoted_string(&self, chars: &mut Peekable<Chars>) -> String {
+    fn tokenize_single_quoted_string(&self, chars: &mut Peekable<Chars<'_>>) -> String {
         //TODO: handle escaped quotes in string
         //TODO: handle newlines in string
         //TODO: handle EOF before terminating quote
@@ -475,7 +475,7 @@ impl<'a> Tokenizer<'a> {
 
     fn tokenize_multiline_comment(
         &self,
-        chars: &mut Peekable<Chars>,
+        chars: &mut Peekable<Chars<'_>>,
     ) -> Result<Option<Token>, TokenizerError> {
         let mut s = String::new();
         let mut maybe_closing_comment = false;
@@ -506,7 +506,7 @@ impl<'a> Tokenizer<'a> {
 
     fn consume_and_return(
         &self,
-        chars: &mut Peekable<Chars>,
+        chars: &mut Peekable<Chars<'_>>,
         t: Token,
     ) -> Result<Option<Token>, TokenizerError> {
         chars.next();

--- a/tests/sqlparser_ansi.rs
+++ b/tests/sqlparser_ansi.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 use sqlparser::dialect::AnsiSqlDialect;
 use sqlparser::sqlast::*;
 use sqlparser::sqlparser::*;

--- a/tests/sqlparser_ansi.rs
+++ b/tests/sqlparser_ansi.rs
@@ -1,6 +1,3 @@
-extern crate log;
-extern crate sqlparser;
-
 use sqlparser::dialect::AnsiSqlDialect;
 use sqlparser::sqlast::*;
 use sqlparser::sqlparser::*;

--- a/tests/sqlparser_ansi.rs
+++ b/tests/sqlparser_ansi.rs
@@ -14,6 +14,6 @@ fn parse_simple_select() {
         }) => {
             assert_eq!(3, projection.len());
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }

--- a/tests/sqlparser_ansi.rs
+++ b/tests/sqlparser_ansi.rs
@@ -5,15 +5,18 @@ use sqlparser::sqlparser::*;
 #[test]
 fn parse_simple_select() {
     let sql = String::from("SELECT id, fname, lname FROM customer WHERE id = 1");
-    let ast = Parser::parse_sql(&AnsiSqlDialect {}, sql).unwrap();
+    let mut ast = Parser::parse_sql(&AnsiSqlDialect {}, sql).unwrap();
     assert_eq!(1, ast.len());
-    match ast.first().unwrap() {
-        SQLStatement::SQLSelect(SQLQuery {
-            body: SQLSetExpr::Select(SQLSelect { projection, .. }),
-            ..
-        }) => {
-            assert_eq!(3, projection.len());
-        }
+    match ast.pop().unwrap() {
+        SQLStatement::SQLQuery(q) => match *q {
+            SQLQuery {
+                body: SQLSetExpr::Select(select),
+                ..
+            } => {
+                assert_eq!(3, select.projection.len());
+            }
+            _ => unreachable!(),
+        },
         _ => unreachable!(),
     }
 }

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -10,8 +10,7 @@ fn parse_delete_statement() {
         SQLStatement::SQLDelete { table_name, .. } => {
             assert_eq!(SQLObjectName(vec!["\"table\"".to_string()]), table_name);
         }
-
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -38,8 +37,7 @@ fn parse_where_delete_statement() {
                 selection.unwrap(),
             );
         }
-
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -468,7 +466,7 @@ fn parse_create_table() {
             assert_eq!(SQLType::Double, c_lng.data_type);
             assert_eq!(true, c_lng.allow_null);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -519,7 +517,7 @@ fn parse_create_external_table() {
             assert_eq!(FileFormat::TEXTFILE, file_format.unwrap());
             assert_eq!("/tmp/example.csv", location.unwrap());
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -975,7 +973,7 @@ fn parse_create_view() {
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(!materialized);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -992,7 +990,7 @@ fn parse_create_materialized_view() {
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(materialized);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -1070,7 +1070,7 @@ fn parse_sql_expr(sql: &str) -> ASTNode {
     generic_ast
 }
 
-fn parse_sql_expr_with(dialect: &Dialect, sql: &str) -> ASTNode {
+fn parse_sql_expr_with(dialect: &dyn Dialect, sql: &str) -> ASTNode {
     let mut tokenizer = Tokenizer::new(dialect, &sql);
     let tokens = tokenizer.tokenize().unwrap();
     let mut parser = Parser::new(tokens);

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -1,3 +1,5 @@
+use matches::assert_matches;
+
 use sqlparser::dialect::*;
 use sqlparser::sqlast::*;
 use sqlparser::sqlparser::*;
@@ -227,23 +229,17 @@ fn parse_not_precedence() {
     use self::ASTNode::*;
     // NOT has higher precedence than OR/AND, so the following must parse as (NOT true) OR true
     let sql = "NOT true OR true";
-    match verified_expr(sql) {
-        SQLBinaryExpr {
-            op: SQLOperator::Or,
-            ..
-        } => assert!(true),
-        _ => assert!(false),
-    };
+    assert_matches!(verified_expr(sql), SQLBinaryExpr {
+        op: SQLOperator::Or,
+        ..
+    });
 
     // But NOT has lower precedence than comparison operators, so the following parses as NOT (a IS NULL)
     let sql = "NOT a IS NULL";
-    match verified_expr(sql) {
-        SQLUnary {
-            operator: SQLOperator::Not,
-            ..
-        } => assert!(true),
-        _ => assert!(false),
-    };
+    assert_matches!(verified_expr(sql), SQLUnary {
+        operator: SQLOperator::Not,
+        ..
+    });
 }
 
 #[test]
@@ -950,14 +946,11 @@ fn parse_multiple_statements() {
 fn parse_scalar_subqueries() {
     use self::ASTNode::*;
     let sql = "(SELECT 1) + (SELECT 2)";
-    match verified_expr(sql) {
-        SQLBinaryExpr {
-            op: SQLOperator::Plus, ..
-            //left: box SQLSubquery { .. },
-            //right: box SQLSubquery { .. },
-        } => assert!(true),
-        _ => assert!(false),
-    };
+    assert_matches!(verified_expr(sql), SQLBinaryExpr {
+        op: SQLOperator::Plus, ..
+        //left: box SQLSubquery { .. },
+        //right: box SQLSubquery { .. },
+    });
 }
 
 #[test]

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -1003,8 +1003,8 @@ fn only<T>(v: &[T]) -> &T {
 
 fn verified_query(query: &str) -> SQLQuery {
     match verified_stmt(query) {
-        SQLStatement::SQLSelect(select) => select,
-        _ => panic!("Expected SELECT"),
+        SQLStatement::SQLQuery(query) => *query,
+        _ => panic!("Expected SQLQuery"),
     }
 }
 
@@ -1017,7 +1017,7 @@ fn expr_from_projection(item: &SQLSelectItem) -> &ASTNode {
 
 fn verified_only_select(query: &str) -> SQLSelect {
     match verified_query(query).body {
-        SQLSetExpr::Select(s) => s,
+        SQLSetExpr::Select(s) => *s,
         _ => panic!("Expected SQLSetExpr::Select"),
     }
 }

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 use matches::assert_matches;
 
 use sqlparser::dialect::*;

--- a/tests/sqlparser_generic.rs
+++ b/tests/sqlparser_generic.rs
@@ -1,6 +1,3 @@
-extern crate log;
-extern crate sqlparser;
-
 use sqlparser::dialect::*;
 use sqlparser::sqlast::*;
 use sqlparser::sqlparser::*;

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 use log::debug;
 
 use sqlparser::dialect::PostgreSqlDialect;

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1,12 +1,9 @@
-extern crate log;
-extern crate sqlparser;
+use log::debug;
 
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::sqlast::*;
 use sqlparser::sqlparser::*;
 use sqlparser::sqltokenizer::*;
-
-use log::*;
 
 #[test]
 fn test_prev_index() {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -39,7 +39,7 @@ fn parse_simple_insert() {
                 values
             );
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -64,7 +64,7 @@ fn parse_common_insert() {
                 values
             );
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -89,7 +89,7 @@ fn parse_complex_insert() {
                 values
             );
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -131,7 +131,7 @@ fn parse_insert_with_columns() {
                 values
             );
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -140,7 +140,7 @@ fn parse_insert_invalid() {
     let sql = String::from("INSERT public.customer (id, name, active) VALUES (1, 2, 3)");
     match Parser::parse_sql(&PostgreSqlDialect {}, sql) {
         Err(_) => {}
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -185,7 +185,7 @@ fn parse_create_table_with_defaults() {
             assert_eq!(SQLType::Varchar(Some(45)), c_lng.data_type);
             assert_eq!(false, c_lng.allow_null);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -254,7 +254,7 @@ fn parse_create_table_from_pg_dump() {
                 c_release_year.data_type
             );
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -293,7 +293,7 @@ fn parse_create_table_with_inherit() {
             assert_eq!(false, c_name.is_primary);
             assert_eq!(true, c_name.is_unique);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -308,7 +308,7 @@ fn parse_alter_table_constraint_primary_key() {
         SQLStatement::SQLAlterTable { name, .. } => {
             assert_eq!(name.to_string(), "bazaar.address");
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 
@@ -321,7 +321,7 @@ fn parse_alter_table_constraint_foreign_key() {
         SQLStatement::SQLAlterTable { name, .. } => {
             assert_eq!(name.to_string(), "public.customer");
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -163,9 +163,9 @@ fn parse_create_table_with_defaults() {
         SQLStatement::SQLCreateTable {
             name,
             columns,
-            external: _,
-            file_format: _,
-            location: _,
+            external: false,
+            file_format: None,
+            location: None,
         } => {
             assert_eq!("public.customer", name.to_string());
             assert_eq!(10, columns.len());
@@ -210,9 +210,9 @@ fn parse_create_table_from_pg_dump() {
         SQLStatement::SQLCreateTable {
             name,
             columns,
-            external: _,
-            file_format: _,
-            location: _,
+            external: false,
+            file_format: None,
+            location: None,
         } => {
             assert_eq!("public.customer", name.to_string());
 
@@ -273,9 +273,9 @@ fn parse_create_table_with_inherit() {
         SQLStatement::SQLCreateTable {
             name,
             columns,
-            external: _,
-            file_format: _,
-            location: _,
+            external: false,
+            file_format: None,
+            location: None,
         } => {
             assert_eq!("bazaar.settings", name.to_string());
 
@@ -407,8 +407,7 @@ fn parse_sql_statements(sql: &str) -> Result<Vec<SQLStatement>, ParserError> {
 fn parse_sql_expr(sql: &str) -> ASTNode {
     debug!("sql: {}", sql);
     let mut parser = parser(sql);
-    let ast = parser.parse_expr().unwrap();
-    ast
+    parser.parse_expr().unwrap()
 }
 
 fn parser(sql: &str) -> Parser {


### PR DESCRIPTION
Most of the changes here are uninteresting, except for:

* The breaking changes to the AST in 50a23101735d479b2c21286c6eeac911d09e7207
* A drive-by bugfix for parsing of the `TIME` data type in 3df2223d953cf5782f86c2e0c0b59be6d8667c17
* The addition of a tiny `matches` crate to dev-dependencies in 08bbce8992b2f5a86880ede500c580476c0ce0bd