### PR TITLE
Implement COLLATE, optional column list in CTEs, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ This is a work in progress but I started some notes on [writing a custom SQL par
 ## Contributing
 
 Contributors are welcome! Please see the [current issues](https://github.com/andygrove/sqlparser-rs/issues) and feel free to file more!
+
+Please run [cargo fmt](https://github.com/rust-lang/rustfmt#on-the-stable-toolchain) to ensure the code is properly formatted.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# We use rustfmt's default settings to format the source code

--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -93,6 +93,11 @@ pub enum ASTNode {
         expr: Box<ASTNode>,
         data_type: SQLType,
     },
+    /// `expr COLLATE collation`
+    SQLCollate {
+        expr: Box<ASTNode>,
+        collation: SQLObjectName,
+    },
     /// Nested expression e.g. `(foo > bar)` or `(1)`
     SQLNested(Box<ASTNode>),
     /// Unary expression
@@ -174,6 +179,11 @@ impl ToString for ASTNode {
                 "CAST({} AS {})",
                 expr.as_ref().to_string(),
                 data_type.to_string()
+            ),
+            ASTNode::SQLCollate { expr, collation } => format!(
+                "{} COLLATE {}",
+                expr.as_ref().to_string(),
+                collation.to_string()
             ),
             ASTNode::SQLNested(ast) => format!("({})", ast.as_ref().to_string()),
             ASTNode::SQLUnary { operator, expr } => {

--- a/src/sqlast/sql_operator.rs
+++ b/src/sqlast/sql_operator.rs
@@ -32,7 +32,7 @@ impl ToString for SQLOperator {
             SQLOperator::GtEq => ">=".to_string(),
             SQLOperator::LtEq => "<=".to_string(),
             SQLOperator::Eq => "=".to_string(),
-            SQLOperator::NotEq => "!=".to_string(),
+            SQLOperator::NotEq => "<>".to_string(),
             SQLOperator::And => "AND".to_string(),
             SQLOperator::Or => "OR".to_string(),
             SQLOperator::Not => "NOT".to_string(),

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -158,7 +158,7 @@ impl Parser {
         let tok = self
             .next_token()
             .ok_or_else(|| ParserError::ParserError("Unexpected EOF".to_string()))?;
-        match tok {
+        let expr = match tok {
             Token::SQLWord(w) => match w.keyword.as_ref() {
                 "TRUE" | "FALSE" | "NULL" => {
                     self.prev_token();
@@ -232,6 +232,15 @@ impl Parser {
                 Ok(expr)
             }
             unexpected => self.expected("an expression", Some(unexpected)),
+        }?;
+
+        if self.parse_keyword("COLLATE") {
+            Ok(ASTNode::SQLCollate {
+                expr: Box::new(expr),
+                collation: self.parse_object_name()?,
+            })
+        } else {
+            Ok(expr)
         }
     }
 

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -1215,12 +1215,19 @@ impl Parser {
         let mut cte = vec![];
         loop {
             let alias = self.parse_identifier()?;
-            // TODO: Optional `( <column list> )`
+            let renamed_columns = if self.consume_token(&Token::LParen) {
+                let cols = self.parse_column_names()?;
+                self.expect_token(&Token::RParen)?;
+                cols
+            } else {
+                vec![]
+            };
             self.expect_keyword("AS")?;
             self.expect_token(&Token::LParen)?;
             cte.push(Cte {
                 alias,
                 query: self.parse_query()?,
+                renamed_columns,
             });
             self.expect_token(&Token::RParen)?;
             if !self.consume_token(&Token::Comma) {

--- a/src/sqltokenizer.rs
+++ b/src/sqltokenizer.rs
@@ -43,7 +43,7 @@ pub enum Token {
     Whitespace(Whitespace),
     /// Equality operator `=`
     Eq,
-    /// Not Equals operator `!=` or `<>`
+    /// Not Equals operator `<>` (or `!=` in some dialects)
     Neq,
     /// Less Than operator `<`
     Lt,
@@ -100,7 +100,7 @@ impl ToString for Token {
             Token::Comma => ",".to_string(),
             Token::Whitespace(ws) => ws.to_string(),
             Token::Eq => "=".to_string(),
-            Token::Neq => "-".to_string(),
+            Token::Neq => "<>".to_string(),
             Token::Lt => "<".to_string(),
             Token::Gt => ">".to_string(),
             Token::LtEq => "<=".to_string(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -221,7 +221,7 @@ fn parse_collate() {
 #[test]
 fn parse_select_string_predicate() {
     let sql = "SELECT id, fname, lname FROM customer \
-               WHERE salary != 'Not Provided' AND salary != ''";
+               WHERE salary <> 'Not Provided' AND salary <> ''";
     let _ast = verified_only_select(sql);
     //TODO: add assertions
 }
@@ -238,7 +238,7 @@ fn parse_escaped_single_quote_string_predicate() {
     use self::ASTNode::*;
     use self::SQLOperator::*;
     let sql = "SELECT id, fname, lname FROM customer \
-               WHERE salary != 'Jim''s salary'";
+               WHERE salary <> 'Jim''s salary'";
     let ast = verified_only_select(sql);
     assert_eq!(
         Some(SQLBinaryExpr {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -210,6 +210,15 @@ fn parse_not() {
 }
 
 #[test]
+fn parse_collate() {
+    let sql = "SELECT name COLLATE \"de_DE\" FROM customer";
+    assert_matches!(
+        only(&all_dialects().verified_only_select(sql).projection),
+        SQLSelectItem::UnnamedExpression(ASTNode::SQLCollate { .. })
+    );
+}
+
+#[test]
 fn parse_select_string_predicate() {
     let sql = "SELECT id, fname, lname FROM customer \
                WHERE salary != 'Not Provided' AND salary != ''";


### PR DESCRIPTION
Also change the "not equals" operator to serialize as `<>` instead of `!=` and add a note about our use of `rustfmt`.