### PR TITLE
Support for MSSQL identifier and alias parsing rules

### DIFF
--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -4,6 +4,10 @@ use crate::dialect::Dialect;
 pub struct MsSqlDialect {}
 
 impl Dialect for MsSqlDialect {
+    fn is_delimited_identifier_start(&self, ch: char) -> bool {
+        ch == '"' || ch == '['
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         // See https://docs.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-2017#rules-for-regular-identifiers
         // We don't support non-latin "letters" currently.

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -213,6 +213,21 @@ fn parse_column_aliases() {
 }
 
 #[test]
+fn test_eof_after_as() {
+    let res = parse_sql_statements("SELECT foo AS");
+    assert_eq!(
+        ParserError::ParserError("Expected an identifier after AS, found: EOF".to_string()),
+        res.unwrap_err()
+    );
+
+    let res = parse_sql_statements("SELECT 1 FROM foo AS");
+    assert_eq!(
+        ParserError::ParserError("Expected an identifier after AS, found: EOF".to_string()),
+        res.unwrap_err()
+    );
+}
+
+#[test]
 fn parse_select_count_wildcard() {
     let sql = "SELECT COUNT(*) FROM customer";
     let select = verified_only_select(sql);

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -28,6 +28,11 @@ fn parse_mssql_identifiers() {
 }
 
 #[test]
+fn parse_mssql_single_quoted_aliases() {
+    let _ = ms_and_generic().one_statement_parses_to("SELECT foo 'alias'", "SELECT foo AS 'alias'");
+}
+
+#[test]
 fn parse_mssql_delimited_identifiers() {
     let _ = ms().one_statement_parses_to(
         "SELECT [a.b!] [FROM] FROM foo [WHERE]",

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -27,7 +27,14 @@ fn parse_mssql_identifiers() {
     };
 }
 
-#[allow(dead_code)]
+#[test]
+fn parse_mssql_delimited_identifiers() {
+    let _ = ms().one_statement_parses_to(
+        "SELECT [a.b!] [FROM] FROM foo [WHERE]",
+        "SELECT [a.b!] AS [FROM] FROM foo AS [WHERE]",
+    );
+}
+
 fn ms() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MsSqlDialect {})],


### PR DESCRIPTION
Add support for parsing `[dbo].[MyTable]` as an identifier for MsSqlDialect only, as it's not easily compatible with Postgesql's `text[]`.

Add support for parsing `SELECT expr 'alias'` (meaning `SELECT expr AS "alias"`) to all dialects, since I didn't find anything it conflicts with.

Add a flag to pick the dialect to the `cli` example.