### PR TITLE
Add FETCH and OFFSET support

### DIFF
--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -155,6 +155,7 @@ define_keywords!(
     EXTRACT,
     FALSE,
     FETCH,
+    FIRST,
     FILTER,
     FIRST_VALUE,
     FLOAT,
@@ -229,6 +230,7 @@ define_keywords!(
     NATURAL,
     NCHAR,
     NCLOB,
+    NEXT,
     NEW,
     NO,
     NONE,
@@ -341,6 +343,7 @@ define_keywords!(
     TABLESAMPLE,
     TEXT,
     THEN,
+    TIES,
     TIME,
     TIMESTAMP,
     TIMEZONE_HOUR,
@@ -396,7 +399,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[&str] = &[
     // Reserved as both a table and a column alias:
     WITH, SELECT, WHERE, GROUP, ORDER, UNION, EXCEPT, INTERSECT,
     // Reserved only as a table alias in the `FROM`/`JOIN` clauses:
-    ON, JOIN, INNER, CROSS, FULL, LEFT, RIGHT, NATURAL, USING, LIMIT,
+    ON, JOIN, INNER, CROSS, FULL, LEFT, RIGHT, NATURAL, USING, LIMIT, OFFSET, FETCH,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`

--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -21,8 +21,8 @@ mod table_key;
 mod value;
 
 pub use self::query::{
-    Cte, Join, JoinConstraint, JoinOperator, SQLOrderByExpr, SQLQuery, SQLSelect, SQLSelectItem,
-    SQLSetExpr, SQLSetOperator, TableFactor,
+    Cte, Fetch, Join, JoinConstraint, JoinOperator, SQLOrderByExpr, SQLQuery, SQLSelect,
+    SQLSelectItem, SQLSetExpr, SQLSetOperator, TableFactor,
 };
 pub use self::sqltype::SQLType;
 pub use self::table_key::{AlterOperation, Key, TableKey};

--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -209,6 +209,7 @@ pub enum TableFactor {
         with_hints: Vec<ASTNode>,
     },
     Derived {
+        lateral: bool,
         subquery: Box<SQLQuery>,
         alias: Option<SQLIdent>,
     },
@@ -235,8 +236,16 @@ impl ToString for TableFactor {
                 }
                 s
             }
-            TableFactor::Derived { subquery, alias } => {
-                let mut s = format!("({})", subquery.to_string());
+            TableFactor::Derived {
+                lateral,
+                subquery,
+                alias,
+            } => {
+                let mut s = String::new();
+                if *lateral {
+                    s += "LATERAL ";
+                }
+                s += &format!("({})", subquery.to_string());
                 if let Some(alias) = alias {
                     s += &format!(" AS {}", alias);
                 }

--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -10,8 +10,12 @@ pub struct SQLQuery {
     pub body: SQLSetExpr,
     /// ORDER BY
     pub order_by: Vec<SQLOrderByExpr>,
-    /// LIMIT
+    /// LIMIT { <N> | ALL }
     pub limit: Option<ASTNode>,
+    /// OFFSET <N> { ROW | ROWS }
+    pub offset: Option<ASTNode>,
+    /// FETCH { FIRST | NEXT } <N> [ PERCENT ] { ROW | ROWS } | { ONLY | WITH TIES }
+    pub fetch: Option<Fetch>,
 }
 
 impl ToString for SQLQuery {
@@ -26,6 +30,13 @@ impl ToString for SQLQuery {
         }
         if let Some(ref limit) = self.limit {
             s += &format!(" LIMIT {}", limit.to_string());
+        }
+        if let Some(ref offset) = self.offset {
+            s += &format!(" OFFSET {} ROWS", offset.to_string());
+        }
+        if let Some(ref fetch) = self.fetch {
+            s.push(' ');
+            s += &fetch.to_string();
         }
         s
     }
@@ -317,6 +328,30 @@ impl ToString for SQLOrderByExpr {
             Some(true) => format!("{} ASC", self.expr.to_string()),
             Some(false) => format!("{} DESC", self.expr.to_string()),
             None => self.expr.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Fetch {
+    pub with_ties: bool,
+    pub percent: bool,
+    pub quantity: Option<ASTNode>,
+}
+
+impl ToString for Fetch {
+    fn to_string(&self) -> String {
+        let extension = if self.with_ties { "WITH TIES" } else { "ONLY" };
+        if let Some(ref quantity) = self.quantity {
+            let percent = if self.percent { " PERCENT" } else { "" };
+            format!(
+                "FETCH FIRST {}{} ROWS {}",
+                quantity.to_string(),
+                percent,
+                extension
+            )
+        } else {
+            format!("FETCH FIRST ROWS {}", extension)
         }
     }
 }


### PR DESCRIPTION
I've added code and passing tests for this, just two points which should be gone over.

First is the ambiguity of the sql spec. Per the ANSI SQL:2011 standard, there is no limit clause, and the order seems to be set in stone.

Obviously, many databases and currently sqlparser support the LIMIT clause. 

POSTGRES seems to support OFFSET without {ROW | ROWS}. LIMIT, OFFSET, FETCH can be reordered in POSTGRES. Having all of LIMIT, OFFSET and FETCH causes a parsing error.

I've implemented it in such a fashion that you can't reorder those clauses and so that you can have all of LIMIT, OFFSET and FETCH. I don't support OFFSET without {ROW | ROWS}

Another point is keywords, in sqlparser, no distinction is made between reserved and non-reserved words. I added a couple new keywords to the keyword list, I hope this should be fine.