### PR TITLE
Replace Option<Vec<T>> with Vec<T>

### DIFF
--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -9,7 +9,7 @@ pub struct SQLQuery {
     /// SELECT or UNION / EXCEPT / INTECEPT
     pub body: SQLSetExpr,
     /// ORDER BY
-    pub order_by: Option<Vec<SQLOrderByExpr>>,
+    pub order_by: Vec<SQLOrderByExpr>,
     /// LIMIT
     pub limit: Option<ASTNode>,
 }
@@ -21,8 +21,8 @@ impl ToString for SQLQuery {
             s += &format!("WITH {} ", comma_separated_string(&self.ctes))
         }
         s += &self.body.to_string();
-        if let Some(ref order_by) = self.order_by {
-            s += &format!(" ORDER BY {}", comma_separated_string(order_by));
+        if !self.order_by.is_empty() {
+            s += &format!(" ORDER BY {}", comma_separated_string(&self.order_by));
         }
         if let Some(ref limit) = self.limit {
             s += &format!(" LIMIT {}", limit.to_string());
@@ -106,7 +106,7 @@ pub struct SQLSelect {
     /// WHERE
     pub selection: Option<ASTNode>,
     /// GROUP BY
-    pub group_by: Option<Vec<ASTNode>>,
+    pub group_by: Vec<ASTNode>,
     /// HAVING
     pub having: Option<ASTNode>,
 }
@@ -127,8 +127,8 @@ impl ToString for SQLSelect {
         if let Some(ref selection) = self.selection {
             s += &format!(" WHERE {}", selection.to_string());
         }
-        if let Some(ref group_by) = self.group_by {
-            s += &format!(" GROUP BY {}", comma_separated_string(group_by));
+        if !self.group_by.is_empty() {
+            s += &format!(" GROUP BY {}", comma_separated_string(&self.group_by));
         }
         if let Some(ref having) = self.having {
             s += &format!(" HAVING {}", having.to_string());
@@ -193,7 +193,7 @@ pub enum TableFactor {
         /// Arguments of a table-valued function, as supported by Postgres
         /// and MSSQL. Note that deprecated MSSQL `FROM foo (NOLOCK)` syntax
         /// will also be parsed as `args`.
-        args: Option<Vec<ASTNode>>,
+        args: Vec<ASTNode>,
         /// MSSQL-specific `WITH (...)` hints such as NOLOCK.
         with_hints: Vec<ASTNode>,
     },
@@ -213,7 +213,7 @@ impl ToString for TableFactor {
                 with_hints,
             } => {
                 let mut s = name.to_string();
-                if let Some(args) = args {
+                if !args.is_empty() {
                     s += &format!("({})", comma_separated_string(args))
                 };
                 if let Some(alias) = alias {

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -1198,9 +1198,9 @@ impl Parser {
         let body = self.parse_query_body(0)?;
 
         let order_by = if self.parse_keywords(vec!["ORDER", "BY"]) {
-            Some(self.parse_order_by_expr_list()?)
+            self.parse_order_by_expr_list()?
         } else {
-            None
+            vec![]
         };
 
         let limit = if self.parse_keyword("LIMIT") {
@@ -1318,9 +1318,9 @@ impl Parser {
         };
 
         let group_by = if self.parse_keywords(vec!["GROUP", "BY"]) {
-            Some(self.parse_expr_list()?)
+            self.parse_expr_list()?
         } else {
-            None
+            vec![]
         };
 
         let having = if self.parse_keyword("HAVING") {
@@ -1351,9 +1351,9 @@ impl Parser {
             let name = self.parse_object_name()?;
             // Postgres, MSSQL: table-valued functions:
             let args = if self.consume_token(&Token::LParen) {
-                Some(self.parse_optional_args()?)
+                self.parse_optional_args()?
             } else {
-                None
+                vec![]
             };
             let alias = self.parse_optional_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?;
             // MSSQL-specific table hints:

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -455,7 +455,7 @@ fn parse_select_order_by() {
     fn chk(sql: &str) {
         let select = verified_query(sql);
         assert_eq!(
-            Some(vec![
+            vec![
                 SQLOrderByExpr {
                     expr: ASTNode::SQLIdentifier("lname".to_string()),
                     asc: Some(true),
@@ -468,7 +468,7 @@ fn parse_select_order_by() {
                     expr: ASTNode::SQLIdentifier("id".to_string()),
                     asc: None,
                 },
-            ]),
+            ],
             select.order_by
         );
     }
@@ -484,7 +484,7 @@ fn parse_select_order_by_limit() {
                ORDER BY lname ASC, fname DESC LIMIT 2";
     let select = verified_query(sql);
     assert_eq!(
-        Some(vec![
+        vec![
             SQLOrderByExpr {
                 expr: ASTNode::SQLIdentifier("lname".to_string()),
                 asc: Some(true),
@@ -493,7 +493,7 @@ fn parse_select_order_by_limit() {
                 expr: ASTNode::SQLIdentifier("fname".to_string()),
                 asc: Some(false),
             },
-        ]),
+        ],
         select.order_by
     );
     assert_eq!(Some(ASTNode::SQLValue(Value::Long(2))), select.limit);
@@ -504,10 +504,10 @@ fn parse_select_group_by() {
     let sql = "SELECT id, fname, lname FROM customer GROUP BY lname, fname";
     let select = verified_only_select(sql);
     assert_eq!(
-        Some(vec![
+        vec![
             ASTNode::SQLIdentifier("lname".to_string()),
             ASTNode::SQLIdentifier("fname".to_string()),
-        ]),
+        ],
         select.group_by
     );
 }
@@ -746,7 +746,7 @@ fn parse_delimited_identifiers() {
         } => {
             assert_eq!(vec![r#""a table""#.to_string()], name.0);
             assert_eq!(r#""alias""#, alias.unwrap());
-            assert!(args.is_none());
+            assert!(args.is_empty());
             assert!(with_hints.is_empty());
         }
         _ => panic!("Expecting TableFactor::Table"),
@@ -870,7 +870,7 @@ fn parse_implicit_join() {
             relation: TableFactor::Table {
                 name: SQLObjectName(vec!["t2".to_string()]),
                 alias: None,
-                args: None,
+                args: vec![],
                 with_hints: vec![],
             },
             join_operator: JoinOperator::Implicit
@@ -888,7 +888,7 @@ fn parse_cross_join() {
             relation: TableFactor::Table {
                 name: SQLObjectName(vec!["t2".to_string()]),
                 alias: None,
-                args: None,
+                args: vec![],
                 with_hints: vec![],
             },
             join_operator: JoinOperator::Cross
@@ -908,7 +908,7 @@ fn parse_joins_on() {
             relation: TableFactor::Table {
                 name: SQLObjectName(vec![relation.into()]),
                 alias,
-                args: None,
+                args: vec![],
                 with_hints: vec![],
             },
             join_operator: f(JoinConstraint::On(ASTNode::SQLBinaryExpr {
@@ -961,7 +961,7 @@ fn parse_joins_using() {
             relation: TableFactor::Table {
                 name: SQLObjectName(vec![relation.into()]),
                 alias,
-                args: None,
+                args: vec![],
                 with_hints: vec![],
             },
             join_operator: f(JoinConstraint::Using(vec!["c1".into()])),


### PR DESCRIPTION
Vectors can already represent the absence of any arguments (i.e., by
being empty), so there is no need to wrap them in an Option.