### PR TITLE
Support arbitrary WITH options for CREATE [TABLE|VIEW]

### DIFF
--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -379,6 +379,7 @@ pub enum SQLStatement {
         name: SQLObjectName,
         query: Box<SQLQuery>,
         materialized: bool,
+        with_options: Vec<SQLOption>,
     },
     /// CREATE TABLE
     SQLCreateTable {
@@ -387,6 +388,7 @@ pub enum SQLStatement {
         /// Optional schema
         columns: Vec<SQLColumnDef>,
         constraints: Vec<TableConstraint>,
+        with_options: Vec<SQLOption>,
         external: bool,
         file_format: Option<FileFormat>,
         location: Option<String>,
@@ -473,12 +475,19 @@ impl ToString for SQLStatement {
                 name,
                 query,
                 materialized,
+                with_options,
             } => {
                 let modifier = if *materialized { " MATERIALIZED" } else { "" };
+                let with_options = if !with_options.is_empty() {
+                    format!(" WITH ({})", comma_separated_string(with_options))
+                } else {
+                    "".into()
+                };
                 format!(
-                    "CREATE{} VIEW {} AS {}",
+                    "CREATE{} VIEW {}{} AS {}",
                     modifier,
                     name.to_string(),
+                    with_options,
                     query.to_string()
                 )
             }
@@ -486,6 +495,7 @@ impl ToString for SQLStatement {
                 name,
                 columns,
                 constraints,
+                with_options,
                 external,
                 file_format,
                 location,
@@ -506,6 +516,9 @@ impl ToString for SQLStatement {
                         file_format.as_ref().unwrap().to_string(),
                         location.as_ref().unwrap()
                     );
+                }
+                if !with_options.is_empty() {
+                    s += &format!(" WITH ({})", comma_separated_string(with_options));
                 }
                 s
             }
@@ -668,5 +681,17 @@ impl SQLObjectType {
             SQLObjectType::Table => "TABLE".into(),
             SQLObjectType::View => "VIEW".into(),
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct SQLOption {
+    pub name: SQLIdent,
+    pub value: Value,
+}
+
+impl ToString for SQLOption {
+    fn to_string(&self) -> String {
+        format!("{} = {}", self.name.to_string(), self.value.to_string())
     }
 }


### PR DESCRIPTION
Both Postgres and MSSQL accept this syntax, though the particular
options they accept differ.