### PR TITLE
Enable Clippy and rustfmt in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,17 @@ rust:
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
   - cargo install --force cargo-travis && export PATH=$HOME/.cargo/bin:$PATH
+  - rustup component add clippy rustfmt
 
 script:
+  # Clippy must be run first, as its lints are only triggered during
+  # compilation. Put another way: after a successful `cargo build`, `cargo
+  # clippy` is guaranteed to produce no results. This bug is known upstream:
+  # https://github.com/rust-lang/rust-clippy/issues/2604.
+  - travis-cargo clippy -- --all-targets --all-features -- -D warnings
   - travis-cargo build
   - travis-cargo test
+  - travis-cargo fmt -- -- --check
 
 after_success:
   - cargo coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - kalakris-cmake
 
 rust:
-  - nightly
+  - stable
 
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1317,7 +1317,7 @@ fn parse_drop_table() {
             );
             assert_eq!(false, cascade);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 
     let sql = "DROP TABLE IF EXISTS foo, bar CASCADE";
@@ -1336,7 +1336,7 @@ fn parse_drop_table() {
             );
             assert_eq!(true, cascade);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 
     let sql = "DROP TABLE";
@@ -1365,7 +1365,7 @@ fn parse_drop_view() {
             );
             assert_eq!(SQLObjectType::View, object_type);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
 }
 


### PR DESCRIPTION
@nickolay what do you think about this? I've found that if Clippy isn't enabled in CI, lint violations creep in quite quickly.