### PR TITLE
Refactor parse_joins

### DIFF
--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -271,14 +271,14 @@ impl ToString for Join {
         }
         fn suffix(constraint: &JoinConstraint) -> String {
             match constraint {
-                JoinConstraint::On(expr) => format!("ON {}", expr.to_string()),
-                JoinConstraint::Using(attrs) => format!("USING({})", attrs.join(", ")),
+                JoinConstraint::On(expr) => format!(" ON {}", expr.to_string()),
+                JoinConstraint::Using(attrs) => format!(" USING({})", attrs.join(", ")),
                 _ => "".to_string(),
             }
         }
         match &self.join_operator {
             JoinOperator::Inner(constraint) => format!(
-                " {}JOIN {} {}",
+                " {}JOIN {}{}",
                 prefix(constraint),
                 self.relation.to_string(),
                 suffix(constraint)
@@ -286,19 +286,19 @@ impl ToString for Join {
             JoinOperator::Cross => format!(" CROSS JOIN {}", self.relation.to_string()),
             JoinOperator::Implicit => format!(", {}", self.relation.to_string()),
             JoinOperator::LeftOuter(constraint) => format!(
-                " {}LEFT JOIN {} {}",
+                " {}LEFT JOIN {}{}",
                 prefix(constraint),
                 self.relation.to_string(),
                 suffix(constraint)
             ),
             JoinOperator::RightOuter(constraint) => format!(
-                " {}RIGHT JOIN {} {}",
+                " {}RIGHT JOIN {}{}",
                 prefix(constraint),
                 self.relation.to_string(),
                 suffix(constraint)
             ),
             JoinOperator::FullOuter(constraint) => format!(
-                " {}FULL JOIN {} {}",
+                " {}FULL JOIN {}{}",
                 prefix(constraint),
                 self.relation.to_string(),
                 suffix(constraint)

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -702,14 +702,10 @@ impl Parser {
     /// Consume the next token if it matches the expected token, otherwise return false
     #[must_use]
     pub fn consume_token(&mut self, expected: &Token) -> bool {
-        match self.peek_token() {
-            Some(ref t) => {
-                if *t == *expected {
-                    self.next_token();
-                    true
-                } else {
-                    false
-                }
+        match &self.peek_token() {
+            Some(t) if *t == *expected => {
+                self.next_token();
+                true
             }
             _ => false,
         }
@@ -1611,10 +1607,9 @@ impl Parser {
         let mut expr_list: Vec<ASTNode> = vec![];
         loop {
             expr_list.push(self.parse_expr()?);
-            match self.peek_token() {
-                Some(Token::Comma) => self.next_token(),
-                _ => break,
-            };
+            if !self.consume_token(&Token::Comma) {
+                break;
+            }
         }
         Ok(expr_list)
     }
@@ -1649,10 +1644,9 @@ impl Parser {
                 }
             }
 
-            match self.peek_token() {
-                Some(Token::Comma) => self.next_token(),
-                _ => break,
-            };
+            if !self.consume_token(&Token::Comma) {
+                break;
+            }
         }
         Ok(projections)
     }
@@ -1672,10 +1666,7 @@ impl Parser {
             };
 
             expr_list.push(SQLOrderByExpr { expr, asc });
-
-            if let Some(Token::Comma) = self.peek_token() {
-                self.next_token();
-            } else {
+            if !self.consume_token(&Token::Comma) {
                 break;
             }
         }


### PR DESCRIPTION
While preparing to add support for the non-standard `CROSS`/`OUTER APPLY` ([an alternative syntax for LATERAL invented by MS and adopted by Oracle](https://blog.jooq.org/2013/12/18/add-lateral-joins-or-cross-apply-to-your-sql-tool-chain/)) I've tweaked the internals of `parse_joins` to reduce code duplication, added tests for `NATURAL` and fixed a couple minor issues (extra whitespace in the serializer and NATURAL being silently eaten when not followed by a JOIN).

(This does _not_ change the AST, and doesn't deal with #83.)