### PR TITLE
Extract a SQLFunction struct

### DIFF
--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -301,12 +301,12 @@ impl Parser {
             None
         };
 
-        Ok(ASTNode::SQLFunction {
+        Ok(ASTNode::SQLFunction(SQLFunction {
             name,
             args,
             over,
             distinct,
-        })
+        }))
     }
 
     pub fn parse_window_frame(&mut self) -> Result<Option<SQLWindowFrame>, ParserError> {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -232,12 +232,12 @@ fn parse_select_count_wildcard() {
     let sql = "SELECT COUNT(*) FROM customer";
     let select = verified_only_select(sql);
     assert_eq!(
-        &ASTNode::SQLFunction {
+        &ASTNode::SQLFunction(SQLFunction {
             name: SQLObjectName(vec!["COUNT".to_string()]),
             args: vec![ASTNode::SQLWildcard],
             over: None,
             distinct: false,
-        },
+        }),
         expr_from_projection(only(&select.projection))
     );
 }
@@ -247,7 +247,7 @@ fn parse_select_count_distinct() {
     let sql = "SELECT COUNT(DISTINCT + x) FROM customer";
     let select = verified_only_select(sql);
     assert_eq!(
-        &ASTNode::SQLFunction {
+        &ASTNode::SQLFunction(SQLFunction {
             name: SQLObjectName(vec!["COUNT".to_string()]),
             args: vec![ASTNode::SQLUnary {
                 operator: SQLOperator::Plus,
@@ -255,7 +255,7 @@ fn parse_select_count_distinct() {
             }],
             over: None,
             distinct: true,
-        },
+        }),
         expr_from_projection(only(&select.projection))
     );
 
@@ -874,12 +874,12 @@ fn parse_scalar_function_in_projection() {
     let sql = "SELECT sqrt(id) FROM foo";
     let select = verified_only_select(sql);
     assert_eq!(
-        &ASTNode::SQLFunction {
+        &ASTNode::SQLFunction(SQLFunction {
             name: SQLObjectName(vec!["sqrt".to_string()]),
             args: vec![ASTNode::SQLIdentifier("id".to_string())],
             over: None,
             distinct: false,
-        },
+        }),
         expr_from_projection(only(&select.projection))
     );
 }
@@ -897,7 +897,7 @@ fn parse_window_functions() {
     let select = verified_only_select(sql);
     assert_eq!(4, select.projection.len());
     assert_eq!(
-        &ASTNode::SQLFunction {
+        &ASTNode::SQLFunction(SQLFunction {
             name: SQLObjectName(vec!["row_number".to_string()]),
             args: vec![],
             over: Some(SQLWindowSpec {
@@ -909,7 +909,7 @@ fn parse_window_functions() {
                 window_frame: None,
             }),
             distinct: false,
-        },
+        }),
         expr_from_projection(&select.projection[0])
     );
 }
@@ -976,12 +976,12 @@ fn parse_delimited_identifiers() {
         expr_from_projection(&select.projection[0]),
     );
     assert_eq!(
-        &ASTNode::SQLFunction {
+        &ASTNode::SQLFunction(SQLFunction {
             name: SQLObjectName(vec![r#""myfun""#.to_string()]),
             args: vec![],
             over: None,
             distinct: false,
-        },
+        }),
         expr_from_projection(&select.projection[1]),
     );
     match &select.projection[2] {


### PR DESCRIPTION
This variant is getting rather large, and it's useful downstream to be
able to pass around SQLFunction nodes without reinventing the wheel.