### PR TITLE
Improve VALUES-related syntax parsing

### DIFF
--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -20,10 +20,12 @@ mod sql_operator;
 mod sqltype;
 mod value;
 
+use std::ops::Deref;
+
 pub use self::ddl::{AlterTableOperation, TableConstraint};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, SQLOrderByExpr, SQLQuery, SQLSelect,
-    SQLSelectItem, SQLSetExpr, SQLSetOperator, TableFactor,
+    SQLSelectItem, SQLSetExpr, SQLSetOperator, SQLValues, TableFactor,
 };
 pub use self::sqltype::SQLType;
 pub use self::value::Value;
@@ -31,9 +33,14 @@ pub use self::value::Value;
 pub use self::sql_operator::SQLOperator;
 
 /// Like `vec.join(", ")`, but for any types implementing ToString.
-fn comma_separated_string<T: ToString>(vec: &[T]) -> String {
-    vec.iter()
-        .map(T::to_string)
+fn comma_separated_string<I>(iter: I) -> String
+where
+    I: IntoIterator,
+    I::Item: Deref,
+    <I::Item as Deref>::Target: ToString,
+{
+    iter.into_iter()
+        .map(|t| t.deref().to_string())
         .collect::<Vec<String>>()
         .join(", ")
 }
@@ -336,7 +343,7 @@ pub enum SQLStatement {
         /// COLUMNS
         columns: Vec<SQLIdent>,
         /// VALUES (vector of rows to insert)
-        values: Vec<Vec<ASTNode>>,
+        values: SQLValues,
     },
     SQLCopy {
         /// TABLE
@@ -408,16 +415,7 @@ impl ToString for SQLStatement {
                 if !columns.is_empty() {
                     s += &format!(" ({})", columns.join(", "));
                 }
-                if !values.is_empty() {
-                    s += &format!(
-                        " VALUES({})",
-                        values
-                            .iter()
-                            .map(|row| comma_separated_string(row))
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    );
-                }
+                s += &format!(" {}", values.to_string());
                 s
             }
             SQLStatement::SQLCopy {
@@ -519,7 +517,7 @@ impl ToString for SQLStatement {
                 "DROP {}{} {}{}",
                 object_type.to_string(),
                 if *if_exists { " IF EXISTS" } else { "" },
-                comma_separated_string(&names),
+                comma_separated_string(names),
                 if *cascade { " CASCADE" } else { "" },
             ),
         }

--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -342,8 +342,8 @@ pub enum SQLStatement {
         table_name: SQLObjectName,
         /// COLUMNS
         columns: Vec<SQLIdent>,
-        /// VALUES (vector of rows to insert)
-        values: SQLValues,
+        /// A SQL query that specifies what to insert
+        source: Box<SQLQuery>,
     },
     SQLCopy {
         /// TABLE
@@ -409,13 +409,13 @@ impl ToString for SQLStatement {
             SQLStatement::SQLInsert {
                 table_name,
                 columns,
-                values,
+                source,
             } => {
-                let mut s = format!("INSERT INTO {}", table_name.to_string());
+                let mut s = format!("INSERT INTO {} ", table_name.to_string());
                 if !columns.is_empty() {
-                    s += &format!(" ({})", columns.join(", "));
+                    s += &format!("({}) ", columns.join(", "));
                 }
-                s += &format!(" {}", values.to_string());
+                s += &source.to_string();
                 s
             }
             SQLStatement::SQLCopy {

--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -58,7 +58,8 @@ pub enum SQLSetExpr {
         left: Box<SQLSetExpr>,
         right: Box<SQLSetExpr>,
     },
-    // TODO: ANSI SQL supports `TABLE` and `VALUES` here.
+    Values(SQLValues),
+    // TODO: ANSI SQL supports `TABLE` here.
 }
 
 impl ToString for SQLSetExpr {
@@ -66,6 +67,7 @@ impl ToString for SQLSetExpr {
         match self {
             SQLSetExpr::Select(s) => s.to_string(),
             SQLSetExpr::Query(q) => format!("({})", q.to_string()),
+            SQLSetExpr::Values(v) => v.to_string(),
             SQLSetExpr::SetOperation {
                 left,
                 right,
@@ -362,5 +364,18 @@ impl ToString for Fetch {
         } else {
             format!("FETCH FIRST ROWS {}", extension)
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SQLValues(pub Vec<Vec<ASTNode>>);
+
+impl ToString for SQLValues {
+    fn to_string(&self) -> String {
+        let rows = self
+            .0
+            .iter()
+            .map(|row| format!("({})", comma_separated_string(row)));
+        format!("VALUES {}", comma_separated_string(rows))
     }
 }

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -1565,12 +1565,11 @@ impl Parser {
         self.expect_keyword("INTO")?;
         let table_name = self.parse_object_name()?;
         let columns = self.parse_parenthesized_column_list(Optional)?;
-        self.expect_keyword("VALUES")?;
-        let values = self.parse_values()?;
+        let source = Box::new(self.parse_query()?);
         Ok(SQLStatement::SQLInsert {
             table_name,
             columns,
-            values,
+            source,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -52,16 +52,23 @@ fn parse_insert_values() {
             SQLStatement::SQLInsert {
                 table_name,
                 columns,
-                values,
+                source,
                 ..
             } => {
                 assert_eq!(table_name.to_string(), expected_table_name);
                 assert_eq!(columns, expected_columns);
-                assert_eq!(values.0.as_slice(), expected_rows);
+                match &source.body {
+                    SQLSetExpr::Values(SQLValues(values)) => {
+                        assert_eq!(values.as_slice(), expected_rows)
+                    }
+                    _ => unreachable!(),
+                }
             }
             _ => unreachable!(),
         }
     }
+
+    verified_stmt("INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)");
 }
 
 #[test]


### PR DESCRIPTION
The first commit allows VALUES clauses in more places; the second commit teaches INSERT to accept things besides VALUES clauses. See individual commit messages for details.