### PR TITLE
Support CREATE TABLE with no columns

### DIFF
--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -833,7 +833,7 @@ impl Parser {
     fn parse_columns(&mut self) -> Result<(Vec<SQLColumnDef>, Vec<TableConstraint>), ParserError> {
         let mut columns = vec![];
         let mut constraints = vec![];
-        if !self.consume_token(&Token::LParen) {
+        if !self.consume_token(&Token::LParen) || self.consume_token(&Token::RParen) {
             return Ok((columns, constraints));
         }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -821,6 +821,12 @@ fn parse_create_external_table() {
 }
 
 #[test]
+fn parse_create_table_empty() {
+    // Zero-column tables are weird, but supported by at least PostgreSQL.
+    let _ = verified_stmt("CREATE TABLE t ()");
+}
+
+#[test]
 fn parse_alter_table_constraints() {
     check_one("CONSTRAINT address_pkey PRIMARY KEY (address_id)");
     check_one("CONSTRAINT uk_task UNIQUE (report_date, task_id)");


### PR DESCRIPTION
This is weird, but supported by PostgreSQL.