### PR TITLE
Fix precedence of unary NOT

### DIFF
--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -580,11 +580,12 @@ impl Parser {
                     // The precedence of NOT varies depending on keyword that
                     // follows it. If it is followed by IN, BETWEEN, or LIKE,
                     // it takes on the precedence of those tokens. Otherwise it
-                    // takes on UNARY_NOT_PREC.
+                    // is not an infix operator, and therefore has zero
+                    // precedence.
                     Some(Token::SQLWord(k)) if k.keyword == "IN" => Ok(Self::BETWEEN_PREC),
                     Some(Token::SQLWord(k)) if k.keyword == "BETWEEN" => Ok(Self::BETWEEN_PREC),
                     Some(Token::SQLWord(k)) if k.keyword == "LIKE" => Ok(Self::BETWEEN_PREC),
-                    _ => Ok(Self::UNARY_NOT_PREC),
+                    _ => Ok(0),
                 },
                 Token::SQLWord(k) if k.keyword == "IS" => Ok(17),
                 Token::SQLWord(k) if k.keyword == "IN" => Ok(Self::BETWEEN_PREC),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -352,7 +352,7 @@ fn parse_not() {
 fn parse_invalid_infix_not() {
     let res = parse_sql_statements("SELECT c FROM t WHERE c NOT (");
     assert_eq!(
-        ParserError::ParserError("Expected IN or BETWEEN after NOT, found: (".to_string()),
+        ParserError::ParserError("Expected end of statement, found: NOT".to_string()),
         res.unwrap_err(),
     );
 }


### PR DESCRIPTION
get_next_precedence deals with left-binding power, not right binding
power. Therefore, when it encounters a standalone NOT operator (i.e., a
"NOT" token that is not followed by "BETWEEN", "LIKE", or "IN"), it
should return 0, because unary NOT is not an infix operator, it's a
prefix operator, and therefore it has no left-binding power.

@nickolay this is as discussed in #93. Making this change does indeed mean that parsing DEFAULT doesn't need to do any special precedence hacks.