### PR TITLE
Properly handle mixed implicit and explicit joins

### DIFF
--- a/src/sqlast/mod.rs
+++ b/src/sqlast/mod.rs
@@ -27,7 +27,7 @@ pub use self::ddl::{
 };
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, SQLOrderByExpr, SQLQuery, SQLSelect,
-    SQLSelectItem, SQLSetExpr, SQLSetOperator, SQLValues, TableAlias, TableFactor,
+    SQLSelectItem, SQLSetExpr, SQLSetOperator, SQLValues, TableAlias, TableFactor, TableWithJoins,
 };
 pub use self::sqltype::SQLType;
 pub use self::value::{SQLDateTimeField, Value};

--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -113,9 +113,7 @@ pub struct SQLSelect {
     /// projection expressions
     pub projection: Vec<SQLSelectItem>,
     /// FROM
-    pub relation: Option<TableFactor>,
-    /// JOIN
-    pub joins: Vec<Join>,
+    pub from: Vec<TableWithJoins>,
     /// WHERE
     pub selection: Option<ASTNode>,
     /// GROUP BY
@@ -131,11 +129,8 @@ impl ToString for SQLSelect {
             if self.distinct { " DISTINCT" } else { "" },
             comma_separated_string(&self.projection)
         );
-        if let Some(ref relation) = self.relation {
-            s += &format!(" FROM {}", relation.to_string());
-        }
-        for join in &self.joins {
-            s += &join.to_string();
+        if !self.from.is_empty() {
+            s += &format!(" FROM {}", comma_separated_string(&self.from));
         }
         if let Some(ref selection) = self.selection {
             s += &format!(" WHERE {}", selection.to_string());
@@ -197,6 +192,22 @@ impl ToString for SQLSelectItem {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct TableWithJoins {
+    pub relation: TableFactor,
+    pub joins: Vec<Join>,
+}
+
+impl ToString for TableWithJoins {
+    fn to_string(&self) -> String {
+        let mut s = self.relation.to_string();
+        for join in &self.joins {
+            s += &join.to_string();
+        }
+        s
+    }
+}
+
 /// A table name or a parenthesized subquery with an optional alias
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub enum TableFactor {
@@ -215,10 +226,7 @@ pub enum TableFactor {
         subquery: Box<SQLQuery>,
         alias: Option<TableAlias>,
     },
-    NestedJoin {
-        base: Box<TableFactor>,
-        joins: Vec<Join>,
-    },
+    NestedJoin(Box<TableWithJoins>),
 }
 
 impl ToString for TableFactor {
@@ -257,12 +265,8 @@ impl ToString for TableFactor {
                 }
                 s
             }
-            TableFactor::NestedJoin { base, joins } => {
-                let mut s = base.to_string();
-                for join in joins {
-                    s += &join.to_string();
-                }
-                format!("({})", s)
+            TableFactor::NestedJoin(table_reference) => {
+                format!("({})", table_reference.to_string())
             }
         }
     }
@@ -313,7 +317,6 @@ impl ToString for Join {
                 suffix(constraint)
             ),
             JoinOperator::Cross => format!(" CROSS JOIN {}", self.relation.to_string()),
-            JoinOperator::Implicit => format!(", {}", self.relation.to_string()),
             JoinOperator::LeftOuter(constraint) => format!(
                 " {}LEFT JOIN {}{}",
                 prefix(constraint),
@@ -342,7 +345,6 @@ pub enum JoinOperator {
     LeftOuter(JoinConstraint),
     RightOuter(JoinConstraint),
     FullOuter(JoinConstraint),
-    Implicit,
     Cross,
 }
 

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -109,7 +109,7 @@ impl Parser {
         match self.next_token() {
             Some(t) => match t {
                 Token::SQLWord(ref w) if w.keyword != "" => match w.keyword.as_ref() {
-                    "SELECT" | "WITH" => {
+                    "SELECT" | "WITH" | "VALUES" => {
                         self.prev_token();
                         Ok(SQLStatement::SQLQuery(Box::new(self.parse_query()?)))
                     }
@@ -133,6 +133,10 @@ impl Parser {
                         w.to_string()
                     )),
                 },
+                Token::LParen => {
+                    self.prev_token();
+                    Ok(SQLStatement::SQLQuery(Box::new(self.parse_query()?)))
+                }
                 unexpected => self.expected(
                     "a keyword at the beginning of a statement",
                     Some(unexpected),

--- a/src/sqlparser.rs
+++ b/src/sqlparser.rs
@@ -1570,13 +1570,15 @@ impl Parser {
         }
         let projection = self.parse_select_list()?;
 
-        let (relation, joins) = if self.parse_keyword("FROM") {
-            let relation = Some(self.parse_table_factor()?);
-            let joins = self.parse_joins()?;
-            (relation, joins)
-        } else {
-            (None, vec![])
-        };
+        let mut from = vec![];
+        if self.parse_keyword("FROM") {
+            loop {
+                from.push(self.parse_table_and_joins()?);
+                if !self.consume_token(&Token::Comma) {
+                    break;
+                }
+            }
+        }
 
         let selection = if self.parse_keyword("WHERE") {
             Some(self.parse_expr()?)
@@ -1599,95 +1601,18 @@ impl Parser {
         Ok(SQLSelect {
             distinct,
             projection,
+            from,
             selection,
-            relation,
-            joins,
             group_by,
             having,
         })
     }
 
-    /// A table name or a parenthesized subquery, followed by optional `[AS] alias`
-    pub fn parse_table_factor(&mut self) -> Result<TableFactor, ParserError> {
-        let lateral = self.parse_keyword("LATERAL");
-        if self.consume_token(&Token::LParen) {
-            if self.parse_keyword("SELECT")
-                || self.parse_keyword("WITH")
-                || self.parse_keyword("VALUES")
-            {
-                self.prev_token();
-                let subquery = Box::new(self.parse_query()?);
-                self.expect_token(&Token::RParen)?;
-                let alias = self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?;
-                Ok(TableFactor::Derived {
-                    lateral,
-                    subquery,
-                    alias,
-                })
-            } else if lateral {
-                parser_err!("Expected subquery after LATERAL, found nested join".to_string())
-            } else {
-                let base = Box::new(self.parse_table_factor()?);
-                let joins = self.parse_joins()?;
-                self.expect_token(&Token::RParen)?;
-                Ok(TableFactor::NestedJoin { base, joins })
-            }
-        } else if lateral {
-            self.expected("subquery after LATERAL", self.peek_token())
-        } else {
-            let name = self.parse_object_name()?;
-            // Postgres, MSSQL: table-valued functions:
-            let args = if self.consume_token(&Token::LParen) {
-                self.parse_optional_args()?
-            } else {
-                vec![]
-            };
-            let alias = self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?;
-            // MSSQL-specific table hints:
-            let mut with_hints = vec![];
-            if self.parse_keyword("WITH") {
-                if self.consume_token(&Token::LParen) {
-                    with_hints = self.parse_expr_list()?;
-                    self.expect_token(&Token::RParen)?;
-                } else {
-                    // rewind, as WITH may belong to the next statement's CTE
-                    self.prev_token();
-                }
-            };
-            Ok(TableFactor::Table {
-                name,
-                alias,
-                args,
-                with_hints,
-            })
-        }
-    }
-
-    fn parse_join_constraint(&mut self, natural: bool) -> Result<JoinConstraint, ParserError> {
-        if natural {
-            Ok(JoinConstraint::Natural)
-        } else if self.parse_keyword("ON") {
-            let constraint = self.parse_expr()?;
-            Ok(JoinConstraint::On(constraint))
-        } else if self.parse_keyword("USING") {
-            let columns = self.parse_parenthesized_column_list(Mandatory)?;
-            Ok(JoinConstraint::Using(columns))
-        } else {
-            self.expected("ON, or USING after JOIN", self.peek_token())
-        }
-    }
-
-    fn parse_joins(&mut self) -> Result<Vec<Join>, ParserError> {
+    pub fn parse_table_and_joins(&mut self) -> Result<TableWithJoins, ParserError> {
+        let relation = self.parse_table_factor()?;
         let mut joins = vec![];
         loop {
             let join = match &self.peek_token() {
-                Some(Token::Comma) => {
-                    self.next_token();
-                    Join {
-                        relation: self.parse_table_factor()?,
-                        join_operator: JoinOperator::Implicit,
-                    }
-                }
                 Some(Token::SQLWord(kw)) if kw.keyword == "CROSS" => {
                     self.next_token();
                     self.expect_keyword("JOIN")?;
@@ -1736,7 +1661,76 @@ impl Parser {
             };
             joins.push(join);
         }
-        Ok(joins)
+        Ok(TableWithJoins { relation, joins })
+    }
+
+    /// A table name or a parenthesized subquery, followed by optional `[AS] alias`
+    pub fn parse_table_factor(&mut self) -> Result<TableFactor, ParserError> {
+        let lateral = self.parse_keyword("LATERAL");
+        if self.consume_token(&Token::LParen) {
+            if self.parse_keyword("SELECT")
+                || self.parse_keyword("WITH")
+                || self.parse_keyword("VALUES")
+            {
+                self.prev_token();
+                let subquery = Box::new(self.parse_query()?);
+                self.expect_token(&Token::RParen)?;
+                let alias = self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?;
+                Ok(TableFactor::Derived {
+                    lateral,
+                    subquery,
+                    alias,
+                })
+            } else if lateral {
+                parser_err!("Expected subquery after LATERAL, found nested join".to_string())
+            } else {
+                let table_reference = self.parse_table_and_joins()?;
+                self.expect_token(&Token::RParen)?;
+                Ok(TableFactor::NestedJoin(Box::new(table_reference)))
+            }
+        } else if lateral {
+            self.expected("subquery after LATERAL", self.peek_token())
+        } else {
+            let name = self.parse_object_name()?;
+            // Postgres, MSSQL: table-valued functions:
+            let args = if self.consume_token(&Token::LParen) {
+                self.parse_optional_args()?
+            } else {
+                vec![]
+            };
+            let alias = self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?;
+            // MSSQL-specific table hints:
+            let mut with_hints = vec![];
+            if self.parse_keyword("WITH") {
+                if self.consume_token(&Token::LParen) {
+                    with_hints = self.parse_expr_list()?;
+                    self.expect_token(&Token::RParen)?;
+                } else {
+                    // rewind, as WITH may belong to the next statement's CTE
+                    self.prev_token();
+                }
+            };
+            Ok(TableFactor::Table {
+                name,
+                alias,
+                args,
+                with_hints,
+            })
+        }
+    }
+
+    fn parse_join_constraint(&mut self, natural: bool) -> Result<JoinConstraint, ParserError> {
+        if natural {
+            Ok(JoinConstraint::Natural)
+        } else if self.parse_keyword("ON") {
+            let constraint = self.parse_expr()?;
+            Ok(JoinConstraint::On(constraint))
+        } else if self.parse_keyword("USING") {
+            let columns = self.parse_parenthesized_column_list(Mandatory)?;
+            Ok(JoinConstraint::Using(columns))
+        } else {
+            self.expected("ON, or USING after JOIN", self.peek_token())
+        }
     }
 
     /// Parse an INSERT statement

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -109,9 +109,13 @@ pub fn all_dialects() -> TestedDialects {
     }
 }
 
-pub fn only<T>(v: &[T]) -> &T {
-    assert_eq!(1, v.len());
-    v.first().unwrap()
+pub fn only<T>(v: impl IntoIterator<Item = T>) -> T {
+    let mut iter = v.into_iter();
+    if let (Some(item), None) = (iter.next(), iter.next()) {
+        item
+    } else {
+        panic!("only called on collection without exactly one item")
+    }
 }
 
 pub fn expr_from_projection(item: &SQLSelectItem) -> &ASTNode {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -182,6 +182,14 @@ fn parse_where_delete_statement() {
 }
 
 #[test]
+fn parse_top_level() {
+    verified_stmt("SELECT 1");
+    verified_stmt("(SELECT 1)");
+    verified_stmt("((SELECT 1))");
+    verified_stmt("VALUES (1)");
+}
+
+#[test]
 fn parse_simple_select() {
     let sql = "SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5";
     let select = verified_only_select(sql);

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -19,8 +19,8 @@ fn parse_mssql_identifiers() {
         expr_from_projection(&select.projection[1]),
     );
     assert_eq!(2, select.projection.len());
-    match select.relation {
-        Some(TableFactor::Table { name, .. }) => {
+    match &only(&select.from).relation {
+        TableFactor::Table { name, .. } => {
             assert_eq!("##temp".to_string(), name.to_string());
         }
         _ => unreachable!(),


### PR DESCRIPTION
Parse a query like

    SELECT * FROM a NATURAL JOIN b, c NATURAL JOIN d

as the SQL specification requires, i.e.:

    from: [
        TableReference {
            relation: TableFactor::Table("a"),
            joins: [Join {
                relation: TableFactor::Table("b"),
                join_operator: JoinOperator::Natural,
            }]
        },
        TableReference {
            relation: TableFactor::Table("c"),
            joins: [Join {
                relation: TableFactor::Table("d"),
                join_operator: JoinOperator::Natural,
            }]
        }
    ]

Previously we were parsing such queries as

    relation: TableFactor::Table("a"),
    joins: [
        Join {
            relation: TableFactor::Table("b"),
            join_operator: JoinOperator::Natural,
        },
        Join {
            relation: TableFactor::Table("c"),
            join_operator: JoinOperator::Implicit,
        },
        Join {
            relation: TableFactor::Table("d"),
            join_operator: JoinOperator::Natural,
        },
    ]

which did not make the join hierarchy clear.