### PR TITLE
[do-not-merge] check that ci enforces rustfmt

### DIFF
--- a/src/sqlast/query.rs
+++ b/src/sqlast/query.rs
@@ -17,7 +17,9 @@ use super::*;
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SQLQuery {
     /// WITH (common table expressions, or CTEs)
-    pub ctes: Vec<Cte>,
+    pub ctes: Vec<
+    Cte
+    >,
     /// SELECT or UNION / EXCEPT / INTECEPT
     pub body: SQLSetExpr,
     /// ORDER BY


### PR DESCRIPTION
Sanity check that CI actually enforces rustfmt. I suspect something is broken.