### PR TITLE
Remove "SQL" prefix from "SQLDateTimeField" struct

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -29,7 +29,7 @@ pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, OrderByExpr, Query, Select, SelectItem,
     SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Values,
 };
-pub use self::value::{SQLDateTimeField, Value};
+pub use self::value::{DateTimeField, Value};
 
 /// Like `vec.join(", ")`, but for any types implementing ToString.
 fn comma_separated_string<I>(iter: I) -> String
@@ -105,7 +105,7 @@ pub enum Expr {
         data_type: DataType,
     },
     Extract {
-        field: SQLDateTimeField,
+        field: DateTimeField,
         expr: Box<Expr>,
     },
     /// `expr COLLATE collation`

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -43,9 +43,9 @@ pub enum Value {
     /// so the user will have to reject intervals like `HOUR TO YEAR`.
     Interval {
         value: String,
-        leading_field: SQLDateTimeField,
+        leading_field: DateTimeField,
         leading_precision: Option<u64>,
-        last_field: Option<SQLDateTimeField>,
+        last_field: Option<DateTimeField>,
         /// The seconds precision can be specified in SQL source as
         /// `INTERVAL '__' SECOND(_, x)` (in which case the `leading_field`
         /// will be `Second` and the `last_field` will be `None`),
@@ -70,7 +70,7 @@ impl ToString for Value {
             Value::Timestamp(v) => format!("TIMESTAMP '{}'", escape_single_quote_string(v)),
             Value::Interval {
                 value,
-                leading_field: SQLDateTimeField::Second,
+                leading_field: DateTimeField::Second,
                 leading_precision: Some(leading_precision),
                 last_field,
                 fractional_seconds_precision: Some(fractional_seconds_precision),
@@ -114,7 +114,7 @@ impl ToString for Value {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash)]
-pub enum SQLDateTimeField {
+pub enum DateTimeField {
     Year,
     Month,
     Day,
@@ -123,15 +123,15 @@ pub enum SQLDateTimeField {
     Second,
 }
 
-impl ToString for SQLDateTimeField {
+impl ToString for DateTimeField {
     fn to_string(&self) -> String {
         match self {
-            SQLDateTimeField::Year => "YEAR".to_string(),
-            SQLDateTimeField::Month => "MONTH".to_string(),
-            SQLDateTimeField::Day => "DAY".to_string(),
-            SQLDateTimeField::Hour => "HOUR".to_string(),
-            SQLDateTimeField::Minute => "MINUTE".to_string(),
-            SQLDateTimeField::Second => "SECOND".to_string(),
+            DateTimeField::Year => "YEAR".to_string(),
+            DateTimeField::Month => "MONTH".to_string(),
+            DateTimeField::Day => "DAY".to_string(),
+            DateTimeField::Hour => "HOUR".to_string(),
+            DateTimeField::Minute => "MINUTE".to_string(),
+            DateTimeField::Second => "SECOND".to_string(),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -431,16 +431,16 @@ impl Parser {
     // operator and interval qualifiers. EXTRACT supports a wider set of
     // date/time fields than interval qualifiers, so this function may need to
     // be split in two.
-    pub fn parse_date_time_field(&mut self) -> Result<SQLDateTimeField, ParserError> {
+    pub fn parse_date_time_field(&mut self) -> Result<DateTimeField, ParserError> {
         let tok = self.next_token();
         if let Some(Token::Word(ref k)) = tok {
             match k.keyword.as_ref() {
-                "YEAR" => Ok(SQLDateTimeField::Year),
-                "MONTH" => Ok(SQLDateTimeField::Month),
-                "DAY" => Ok(SQLDateTimeField::Day),
-                "HOUR" => Ok(SQLDateTimeField::Hour),
-                "MINUTE" => Ok(SQLDateTimeField::Minute),
-                "SECOND" => Ok(SQLDateTimeField::Second),
+                "YEAR" => Ok(DateTimeField::Year),
+                "MONTH" => Ok(DateTimeField::Month),
+                "DAY" => Ok(DateTimeField::Day),
+                "HOUR" => Ok(DateTimeField::Hour),
+                "MINUTE" => Ok(DateTimeField::Minute),
+                "SECOND" => Ok(DateTimeField::Second),
                 _ => self.expected("date/time field", tok)?,
             }
         } else {
@@ -478,7 +478,7 @@ impl Parser {
         let leading_field = self.parse_date_time_field()?;
 
         let (leading_precision, last_field, fsec_precision) =
-            if leading_field == SQLDateTimeField::Second {
+            if leading_field == DateTimeField::Second {
                 // SQL mandates special syntax for `SECOND TO SECOND` literals.
                 // Instead of
                 //     `SECOND [(<leading precision>)] TO SECOND[(<fractional seconds precision>)]`
@@ -491,7 +491,7 @@ impl Parser {
                 let leading_precision = self.parse_optional_precision()?;
                 if self.parse_keyword("TO") {
                     let last_field = Some(self.parse_date_time_field()?);
-                    let fsec_precision = if last_field == Some(SQLDateTimeField::Second) {
+                    let fsec_precision = if last_field == Some(DateTimeField::Second) {
                         self.parse_optional_precision()?
                     } else {
                         None

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -845,7 +845,7 @@ fn parse_extract() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Extract {
-            field: SQLDateTimeField::Year,
+            field: DateTimeField::Year,
             expr: Box::new(Expr::Identifier("d".to_string())),
         },
         expr_from_projection(only(&select.projection)),
@@ -1236,9 +1236,9 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "1-1".into(),
-            leading_field: SQLDateTimeField::Year,
+            leading_field: DateTimeField::Year,
             leading_precision: None,
-            last_field: Some(SQLDateTimeField::Month),
+            last_field: Some(DateTimeField::Month),
             fractional_seconds_precision: None,
         }),
         expr_from_projection(only(&select.projection)),
@@ -1249,9 +1249,9 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "01:01.01".into(),
-            leading_field: SQLDateTimeField::Minute,
+            leading_field: DateTimeField::Minute,
             leading_precision: Some(5),
-            last_field: Some(SQLDateTimeField::Second),
+            last_field: Some(DateTimeField::Second),
             fractional_seconds_precision: Some(5),
         }),
         expr_from_projection(only(&select.projection)),
@@ -1262,7 +1262,7 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "1".into(),
-            leading_field: SQLDateTimeField::Second,
+            leading_field: DateTimeField::Second,
             leading_precision: Some(5),
             last_field: None,
             fractional_seconds_precision: Some(4),
@@ -1275,7 +1275,7 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "10".into(),
-            leading_field: SQLDateTimeField::Hour,
+            leading_field: DateTimeField::Hour,
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
@@ -1288,7 +1288,7 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "10".into(),
-            leading_field: SQLDateTimeField::Hour,
+            leading_field: DateTimeField::Hour,
             leading_precision: Some(1),
             last_field: None,
             fractional_seconds_precision: None,


### PR DESCRIPTION
I realized a moment too late that I'd missed a type name in
when removing the "SQL" prefix from types in ac555d7e8. As far as I can
tell, this was the only oversight.