### PR TITLE
implement fmt::Display instead of ToString

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 use super::ObjectName;
+use std::fmt;
 
 /// SQL data types
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -65,47 +66,53 @@ pub enum DataType {
     Array(Box<DataType>),
 }
 
-impl ToString for DataType {
-    fn to_string(&self) -> String {
+impl fmt::Display for DataType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            DataType::Char(size) => format_type_with_optional_length("char", size),
-            DataType::Varchar(size) => format_type_with_optional_length("character varying", size),
-            DataType::Uuid => "uuid".to_string(),
-            DataType::Clob(size) => format!("clob({})", size),
-            DataType::Binary(size) => format!("binary({})", size),
-            DataType::Varbinary(size) => format!("varbinary({})", size),
-            DataType::Blob(size) => format!("blob({})", size),
+            DataType::Char(size) => format_type_with_optional_length(f, "char", size),
+            DataType::Varchar(size) => {
+                format_type_with_optional_length(f, "character varying", size)
+            }
+            DataType::Uuid => write!(f, "uuid"),
+            DataType::Clob(size) => write!(f, "clob({})", size),
+            DataType::Binary(size) => write!(f, "binary({})", size),
+            DataType::Varbinary(size) => write!(f, "varbinary({})", size),
+            DataType::Blob(size) => write!(f, "blob({})", size),
             DataType::Decimal(precision, scale) => {
                 if let Some(scale) = scale {
-                    format!("numeric({},{})", precision.unwrap(), scale)
+                    write!(f, "numeric({},{})", precision.unwrap(), scale)
                 } else {
-                    format_type_with_optional_length("numeric", precision)
+                    format_type_with_optional_length(f, "numeric", precision)
                 }
             }
-            DataType::Float(size) => format_type_with_optional_length("float", size),
-            DataType::SmallInt => "smallint".to_string(),
-            DataType::Int => "int".to_string(),
-            DataType::BigInt => "bigint".to_string(),
-            DataType::Real => "real".to_string(),
-            DataType::Double => "double".to_string(),
-            DataType::Boolean => "boolean".to_string(),
-            DataType::Date => "date".to_string(),
-            DataType::Time => "time".to_string(),
-            DataType::Timestamp => "timestamp".to_string(),
-            DataType::Interval => "interval".to_string(),
-            DataType::Regclass => "regclass".to_string(),
-            DataType::Text => "text".to_string(),
-            DataType::Bytea => "bytea".to_string(),
-            DataType::Array(ty) => format!("{}[]", ty.to_string()),
-            DataType::Custom(ty) => ty.to_string(),
+            DataType::Float(size) => format_type_with_optional_length(f, "float", size),
+            DataType::SmallInt => write!(f, "smallint"),
+            DataType::Int => write!(f, "int"),
+            DataType::BigInt => write!(f, "bigint"),
+            DataType::Real => write!(f, "real"),
+            DataType::Double => write!(f, "double"),
+            DataType::Boolean => write!(f, "boolean"),
+            DataType::Date => write!(f, "date"),
+            DataType::Time => write!(f, "time"),
+            DataType::Timestamp => write!(f, "timestamp"),
+            DataType::Interval => write!(f, "interval"),
+            DataType::Regclass => write!(f, "regclass"),
+            DataType::Text => write!(f, "text"),
+            DataType::Bytea => write!(f, "bytea"),
+            DataType::Array(ty) => write!(f, "{}[]", ty),
+            DataType::Custom(ty) => write!(f, "{}", ty),
         }
     }
 }
 
-fn format_type_with_optional_length(sql_type: &str, len: &Option<u64>) -> String {
-    let mut s = sql_type.to_string();
+fn format_type_with_optional_length(
+    f: &mut fmt::Formatter,
+    sql_type: &'static str,
+    len: &Option<u64>,
+) -> fmt::Result {
+    write!(f, "{}", sql_type)?;
     if let Some(len) = len {
-        s += &format!("({})", len);
+        write!(f, "({})", len)?;
     }
-    s
+    Ok(())
 }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1,6 +1,7 @@
 //! AST types specific to CREATE/ALTER variants of `SQLStatement`
 //! (commonly referred to as Data Definition Language, or DDL)
-use super::{DataType, Expr, Ident, ObjectName};
+use super::{display_comma_separated, DataType, Expr, Ident, ObjectName};
+use std::fmt;
 
 /// An `ALTER TABLE` (`SQLStatement::SQLAlterTable`) operation
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11,11 +12,11 @@ pub enum AlterTableOperation {
     DropConstraint { name: Ident },
 }
 
-impl ToString for AlterTableOperation {
-    fn to_string(&self) -> String {
+impl fmt::Display for AlterTableOperation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AlterTableOperation::AddConstraint(c) => format!("ADD {}", c.to_string()),
-            AlterTableOperation::DropConstraint { name } => format!("DROP CONSTRAINT {}", name),
+            AlterTableOperation::AddConstraint(c) => write!(f, "ADD {}", c),
+            AlterTableOperation::DropConstraint { name } => write!(f, "DROP CONSTRAINT {}", name),
         }
     }
 }
@@ -46,36 +47,36 @@ pub enum TableConstraint {
     },
 }
 
-impl ToString for TableConstraint {
-    fn to_string(&self) -> String {
+impl fmt::Display for TableConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TableConstraint::Unique {
                 name,
                 columns,
                 is_primary,
-            } => format!(
+            } => write!(
+                f,
                 "{}{} ({})",
-                format_constraint_name(name),
+                display_constraint_name(name),
                 if *is_primary { "PRIMARY KEY" } else { "UNIQUE" },
-                columns.join(", ")
+                display_comma_separated(columns)
             ),
             TableConstraint::ForeignKey {
                 name,
                 columns,
                 foreign_table,
                 referred_columns,
-            } => format!(
+            } => write!(
+                f,
                 "{}FOREIGN KEY ({}) REFERENCES {}({})",
-                format_constraint_name(name),
-                columns.join(", "),
-                foreign_table.to_string(),
-                referred_columns.join(", ")
+                display_constraint_name(name),
+                display_comma_separated(columns),
+                foreign_table,
+                display_comma_separated(referred_columns)
             ),
-            TableConstraint::Check { name, expr } => format!(
-                "{}CHECK ({})",
-                format_constraint_name(name),
-                expr.to_string()
-            ),
+            TableConstraint::Check { name, expr } => {
+                write!(f, "{}CHECK ({})", display_constraint_name(name), expr)
+            }
         }
     }
 }
@@ -89,18 +90,13 @@ pub struct ColumnDef {
     pub options: Vec<ColumnOptionDef>,
 }
 
-impl ToString for ColumnDef {
-    fn to_string(&self) -> String {
-        format!(
-            "{} {}{}",
-            self.name,
-            self.data_type.to_string(),
-            self.options
-                .iter()
-                .map(|c| format!(" {}", c.to_string()))
-                .collect::<Vec<_>>()
-                .join("")
-        )
+impl fmt::Display for ColumnDef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.name, self.data_type)?;
+        for option in &self.options {
+            write!(f, " {}", option)?;
+        }
+        Ok(())
     }
 }
 
@@ -126,13 +122,9 @@ pub struct ColumnOptionDef {
     pub option: ColumnOption,
 }
 
-impl ToString for ColumnOptionDef {
-    fn to_string(&self) -> String {
-        format!(
-            "{}{}",
-            format_constraint_name(&self.name),
-            self.option.to_string()
-        )
+impl fmt::Display for ColumnOptionDef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}{}", display_constraint_name(&self.name), self.option)
     }
 }
 
@@ -160,35 +152,39 @@ pub enum ColumnOption {
     Check(Expr),
 }
 
-impl ToString for ColumnOption {
-    fn to_string(&self) -> String {
+impl fmt::Display for ColumnOption {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ColumnOption::*;
         match self {
-            Null => "NULL".to_string(),
-            NotNull => "NOT NULL".to_string(),
-            Default(expr) => format!("DEFAULT {}", expr.to_string()),
+            Null => write!(f, "NULL"),
+            NotNull => write!(f, "NOT NULL"),
+            Default(expr) => write!(f, "DEFAULT {}", expr),
             Unique { is_primary } => {
-                if *is_primary {
-                    "PRIMARY KEY".to_string()
-                } else {
-                    "UNIQUE".to_string()
-                }
+                write!(f, "{}", if *is_primary { "PRIMARY KEY" } else { "UNIQUE" })
             }
             ForeignKey {
                 foreign_table,
                 referred_columns,
-            } => format!(
+            } => write!(
+                f,
                 "REFERENCES {} ({})",
-                foreign_table.to_string(),
-                referred_columns.join(", ")
+                foreign_table,
+                display_comma_separated(referred_columns)
             ),
-            Check(expr) => format!("CHECK ({})", expr.to_string(),),
+            Check(expr) => write!(f, "CHECK ({})", expr),
         }
     }
 }
 
-fn format_constraint_name(name: &Option<Ident>) -> String {
-    name.as_ref()
-        .map(|name| format!("CONSTRAINT {} ", name))
-        .unwrap_or_default()
+fn display_constraint_name<'a>(name: &'a Option<Ident>) -> impl fmt::Display + 'a {
+    struct ConstraintName<'a>(&'a Option<Ident>);
+    impl<'a> fmt::Display for ConstraintName<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            if let Some(name) = self.0 {
+                write!(f, "CONSTRAINT {} ", name)?;
+            }
+            Ok(())
+        }
+    }
+    ConstraintName(name)
 }

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 /// Unary operators
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum UnaryOperator {
@@ -18,13 +20,17 @@ pub enum UnaryOperator {
     Not,
 }
 
-impl ToString for UnaryOperator {
-    fn to_string(&self) -> String {
-        match self {
-            UnaryOperator::Plus => "+".to_string(),
-            UnaryOperator::Minus => "-".to_string(),
-            UnaryOperator::Not => "NOT".to_string(),
-        }
+impl fmt::Display for UnaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                UnaryOperator::Plus => "+",
+                UnaryOperator::Minus => "-",
+                UnaryOperator::Not => "NOT",
+            }
+        )
     }
 }
 
@@ -48,24 +54,28 @@ pub enum BinaryOperator {
     NotLike,
 }
 
-impl ToString for BinaryOperator {
-    fn to_string(&self) -> String {
-        match self {
-            BinaryOperator::Plus => "+".to_string(),
-            BinaryOperator::Minus => "-".to_string(),
-            BinaryOperator::Multiply => "*".to_string(),
-            BinaryOperator::Divide => "/".to_string(),
-            BinaryOperator::Modulus => "%".to_string(),
-            BinaryOperator::Gt => ">".to_string(),
-            BinaryOperator::Lt => "<".to_string(),
-            BinaryOperator::GtEq => ">=".to_string(),
-            BinaryOperator::LtEq => "<=".to_string(),
-            BinaryOperator::Eq => "=".to_string(),
-            BinaryOperator::NotEq => "<>".to_string(),
-            BinaryOperator::And => "AND".to_string(),
-            BinaryOperator::Or => "OR".to_string(),
-            BinaryOperator::Like => "LIKE".to_string(),
-            BinaryOperator::NotLike => "NOT LIKE".to_string(),
-        }
+impl fmt::Display for BinaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BinaryOperator::Plus => "+",
+                BinaryOperator::Minus => "-",
+                BinaryOperator::Multiply => "*",
+                BinaryOperator::Divide => "/",
+                BinaryOperator::Modulus => "%",
+                BinaryOperator::Gt => ">",
+                BinaryOperator::Lt => "<",
+                BinaryOperator::GtEq => ">=",
+                BinaryOperator::LtEq => "<=",
+                BinaryOperator::Eq => "=",
+                BinaryOperator::NotEq => "<>",
+                BinaryOperator::And => "AND",
+                BinaryOperator::Or => "OR",
+                BinaryOperator::Like => "LIKE",
+                BinaryOperator::NotLike => "NOT LIKE",
+            }
+        )
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,7 @@ use super::dialect::keywords;
 use super::dialect::Dialect;
 use super::tokenizer::*;
 use std::error::Error;
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParserError {
@@ -52,8 +53,8 @@ impl From<TokenizerError> for ParserError {
     }
 }
 
-impl std::fmt::Display for ParserError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for ParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "sql parser error: {}",
@@ -728,7 +729,7 @@ impl Parser {
         parser_err!(format!(
             "Expected {}, found: {}",
             expected,
-            found.map_or("EOF".to_string(), |t| t.to_string())
+            found.map_or_else(|| "EOF".to_string(), |t| format!("{}", t))
         ))
     }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -21,6 +21,7 @@ use std::str::Chars;
 
 use super::dialect::keywords::ALL_KEYWORDS;
 use super::dialect::Dialect;
+use std::fmt;
 
 /// SQL Token enumeration
 #[derive(Debug, Clone, PartialEq)]
@@ -89,40 +90,40 @@ pub enum Token {
     RBrace,
 }
 
-impl ToString for Token {
-    fn to_string(&self) -> String {
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Token::Word(ref w) => w.to_string(),
-            Token::Number(ref n) => n.to_string(),
-            Token::Char(ref c) => c.to_string(),
-            Token::SingleQuotedString(ref s) => format!("'{}'", s),
-            Token::NationalStringLiteral(ref s) => format!("N'{}'", s),
-            Token::HexStringLiteral(ref s) => format!("X'{}'", s),
-            Token::Comma => ",".to_string(),
-            Token::Whitespace(ws) => ws.to_string(),
-            Token::Eq => "=".to_string(),
-            Token::Neq => "<>".to_string(),
-            Token::Lt => "<".to_string(),
-            Token::Gt => ">".to_string(),
-            Token::LtEq => "<=".to_string(),
-            Token::GtEq => ">=".to_string(),
-            Token::Plus => "+".to_string(),
-            Token::Minus => "-".to_string(),
-            Token::Mult => "*".to_string(),
-            Token::Div => "/".to_string(),
-            Token::Mod => "%".to_string(),
-            Token::LParen => "(".to_string(),
-            Token::RParen => ")".to_string(),
-            Token::Period => ".".to_string(),
-            Token::Colon => ":".to_string(),
-            Token::DoubleColon => "::".to_string(),
-            Token::SemiColon => ";".to_string(),
-            Token::Backslash => "\\".to_string(),
-            Token::LBracket => "[".to_string(),
-            Token::RBracket => "]".to_string(),
-            Token::Ampersand => "&".to_string(),
-            Token::LBrace => "{".to_string(),
-            Token::RBrace => "}".to_string(),
+            Token::Word(ref w) => write!(f, "{}", w),
+            Token::Number(ref n) => f.write_str(n),
+            Token::Char(ref c) => write!(f, "{}", c),
+            Token::SingleQuotedString(ref s) => write!(f, "'{}'", s),
+            Token::NationalStringLiteral(ref s) => write!(f, "N'{}'", s),
+            Token::HexStringLiteral(ref s) => write!(f, "X'{}'", s),
+            Token::Comma => f.write_str(","),
+            Token::Whitespace(ws) => write!(f, "{}", ws),
+            Token::Eq => f.write_str("="),
+            Token::Neq => f.write_str("<>"),
+            Token::Lt => f.write_str("<"),
+            Token::Gt => f.write_str(">"),
+            Token::LtEq => f.write_str("<="),
+            Token::GtEq => f.write_str(">="),
+            Token::Plus => f.write_str("+"),
+            Token::Minus => f.write_str("-"),
+            Token::Mult => f.write_str("*"),
+            Token::Div => f.write_str("/"),
+            Token::Mod => f.write_str("%"),
+            Token::LParen => f.write_str("("),
+            Token::RParen => f.write_str(")"),
+            Token::Period => f.write_str("."),
+            Token::Colon => f.write_str(":"),
+            Token::DoubleColon => f.write_str("::"),
+            Token::SemiColon => f.write_str(";"),
+            Token::Backslash => f.write_str("\\"),
+            Token::LBracket => f.write_str("["),
+            Token::RBracket => f.write_str("]"),
+            Token::Ampersand => f.write_str("&"),
+            Token::LBrace => f.write_str("{"),
+            Token::RBrace => f.write_str("}"),
         }
     }
 }
@@ -164,13 +165,13 @@ pub struct Word {
     pub keyword: String,
 }
 
-impl ToString for Word {
-    fn to_string(&self) -> String {
+impl fmt::Display for Word {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.quote_style {
             Some(s) if s == '"' || s == '[' || s == '`' => {
-                format!("{}{}{}", s, self.value, Word::matching_end_quote(s))
+                write!(f, "{}{}{}", s, self.value, Word::matching_end_quote(s))
             }
-            None => self.value.clone(),
+            None => f.write_str(&self.value),
             _ => panic!("Unexpected quote_style!"),
         }
     }
@@ -195,14 +196,14 @@ pub enum Whitespace {
     MultiLineComment(String),
 }
 
-impl ToString for Whitespace {
-    fn to_string(&self) -> String {
+impl fmt::Display for Whitespace {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Whitespace::Space => " ".to_string(),
-            Whitespace::Newline => "\n".to_string(),
-            Whitespace::Tab => "\t".to_string(),
-            Whitespace::SingleLineComment(s) => format!("--{}", s),
-            Whitespace::MultiLineComment(s) => format!("/*{}*/", s),
+            Whitespace::Space => f.write_str(" "),
+            Whitespace::Newline => f.write_str("\n"),
+            Whitespace::Tab => f.write_str("\t"),
+            Whitespace::SingleLineComment(s) => write!(f, "--{}", s),
+            Whitespace::MultiLineComment(s) => write!(f, "/*{}*/", s),
         }
     }
 }


### PR DESCRIPTION
As mentioned in the documentation for [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) implementing [`Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) should be prefered.

This should be faster and use less memory because no intermediate `String`s are created.