### PR TITLE
Allow semicolon after start transaction

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2026,7 +2026,7 @@ impl Parser {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadOnly)
             } else if self.parse_keywords(vec!["READ", "WRITE"]) {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadWrite)
-            } else if required || self.peek_token().is_some() {
+            } else if required {
                 self.expected("transaction mode", self.peek_token())?
             } else {
                 break;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2455,6 +2455,17 @@ fn parse_start_transaction() {
     verified_stmt("START TRANSACTION ISOLATION LEVEL REPEATABLE READ");
     verified_stmt("START TRANSACTION ISOLATION LEVEL SERIALIZABLE");
 
+    // Regression test for https://github.com/andygrove/sqlparser-rs/pull/139,
+    // in which START TRANSACTION would fail to parse if followed by a statement
+    // terminator.
+    assert_eq!(
+        parse_sql_statements("START TRANSACTION; SELECT 1"),
+        Ok(vec![
+            verified_stmt("START TRANSACTION"),
+            verified_stmt("SELECT 1"),
+        ])
+    );
+
     let res = parse_sql_statements("START TRANSACTION ISOLATION LEVEL BAD");
     assert_eq!(
         ParserError::ParserError("Expected isolation level, found: BAD".to_string()),
@@ -2463,7 +2474,7 @@ fn parse_start_transaction() {
 
     let res = parse_sql_statements("START TRANSACTION BAD");
     assert_eq!(
-        ParserError::ParserError("Expected transaction mode, found: BAD".to_string()),
+        ParserError::ParserError("Expected end of statement, found: BAD".to_string()),
         res.unwrap_err()
     );
 


### PR DESCRIPTION
Currently, the parser returns an `Err` if there is a semicolon after a start transaction statement, despite this being valid SQL. For example,
```sql
START TRANSACTION
```
parses correctly, but
```sql
START TRANSACTION; SELECT * FROM T
```
does not.

This change would allow a semicolon delimiter/terminator after a start transaction statement.
