### PR TITLE
Support quoted identifiers in AST as well

### DIFF
--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -23,11 +23,11 @@ fn parse_mssql_identifiers() {
     let sql = "SELECT @@version, _foo$123 FROM ##temp";
     let select = ms_and_generic().verified_only_select(sql);
     assert_eq!(
-        &Expr::Identifier("@@version".to_string()),
+        &Expr::Identifier(Ident::new("@@version")),
         expr_from_projection(&select.projection[0]),
     );
     assert_eq!(
-        &Expr::Identifier("_foo$123".to_string()),
+        &Expr::Identifier(Ident::new("_foo$123")),
         expr_from_projection(&select.projection[1]),
     );
     assert_eq!(2, select.projection.len());

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -26,7 +26,7 @@ fn parse_identifiers() {
 
 #[test]
 fn parse_show_columns() {
-    let table_name = ObjectName(vec!["mytable".to_string()]);
+    let table_name = ObjectName(vec![Ident::new("mytable")]);
     assert_eq!(
         mysql_and_generic().verified_stmt("SHOW COLUMNS FROM mytable"),
         Statement::ShowColumns {
@@ -41,7 +41,7 @@ fn parse_show_columns() {
         Statement::ShowColumns {
             extended: false,
             full: false,
-            table_name: ObjectName(vec!["mydb".to_string(), "mytable".to_string()]),
+            table_name: ObjectName(vec![Ident::new("mydb"), Ident::new("mytable")]),
             filter: None,
         }
     );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -79,7 +79,7 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "last_name".into(),
                         data_type: DataType::Varchar(Some(45)),
-                        collation: Some(ObjectName(vec!["\"es_ES\"".into()])),
+                        collation: Some(ObjectName(vec![Ident::with_quote('"', "es_ES")])),
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull,


### PR DESCRIPTION
As described in #140, the tokenizer already handles quoted identifiers but the current AST drops that information onto the floor again. This pull request adds the same kind of quoted identifier support to the AST, replacing the `Ident` type alias for `String` with a struct that closely resembles `Word`. The changes are relatively small, with most lines uplifting the tests.

This pull request closes #140. I am out of office next week (i.e., the one starting Monday 10/21). So please feel free to merge (or to make minor changes).