### PR TITLE
Add support for MSSQL's SELECT TOP N syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -27,7 +27,7 @@ pub use self::ddl::{
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, OrderByExpr, Query, Select, SelectItem,
-    SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Values,
+    SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Top, Values,
 };
 pub use self::value::{DateTimeField, Value};
 

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -134,11 +134,13 @@ impl fmt::Display for Select {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SELECT{}", if self.distinct { " DISTINCT" } else { "" })?;
         if let Some(ref top) = self.top {
-            write!(f,
-                   " TOP ({}){}{}",
-                   top,
-                   if self.percent { " PERCENT" } else { "" },
-                   if self.with_ties { " WITH TIES"} else { "" })?;
+            write!(
+                f,
+                " TOP ({}){}{}",
+                top,
+                if self.percent { " PERCENT" } else { "" },
+                if self.with_ties { " WITH TIES" } else { "" }
+            )?;
         }
         write!(f, " {}", display_comma_separated(&self.projection))?;
         if !self.from.is_empty() {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -114,10 +114,8 @@ impl fmt::Display for SetOperator {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Select {
     pub distinct: bool,
-    /// top and percent are MSSQL only
-    pub top: Option<Expr>,
-    pub percent: bool,
-    pub with_ties: bool,
+    /// MSSQL syntax: `TOP (<N>) [ PERCENT ] [ WITH TIES ]`
+    pub top: Option<Top>,
     /// projection expressions
     pub projection: Vec<SelectItem>,
     /// FROM
@@ -413,6 +411,26 @@ impl fmt::Display for Fetch {
             write!(f, "FETCH FIRST {}{} ROWS {}", quantity, percent, extension)
         } else {
             write!(f, "FETCH FIRST ROWS {}", extension)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Top {
+    /// SQL semantic equivalent of LIMIT but with same structure as FETCH.
+    pub with_ties: bool,
+    pub percent: bool,
+    pub quantity: Option<Expr>,
+}
+
+impl fmt::Display for Top {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let extension = if self.with_ties { " WITH TIES" } else { "" };
+        if let Some(ref quantity) = self.quantity {
+            let percent = if self.percent { " PERCENT" } else { "" };
+            write!(f, "TOP ({}) {}{}", quantity, percent, extension)
+        } else {
+            write!(f, "TOP{}", extension)
         }
     }
 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -132,13 +132,7 @@ impl fmt::Display for Select {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SELECT{}", if self.distinct { " DISTINCT" } else { "" })?;
         if let Some(ref top) = self.top {
-            write!(
-                f,
-                " TOP ({}){}{}",
-                top,
-                if self.percent { " PERCENT" } else { "" },
-                if self.with_ties { " WITH TIES" } else { "" }
-            )?;
+            write!(f, " {}", top)?;
         }
         write!(f, " {}", display_comma_separated(&self.projection))?;
         if !self.from.is_empty() {
@@ -428,7 +422,7 @@ impl fmt::Display for Top {
         let extension = if self.with_ties { " WITH TIES" } else { "" };
         if let Some(ref quantity) = self.quantity {
             let percent = if self.percent { " PERCENT" } else { "" };
-            write!(f, "TOP ({}) {}{}", quantity, percent, extension)
+            write!(f, "TOP ({}){}{}", quantity, percent, extension)
         } else {
             write!(f, "TOP{}", extension)
         }

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -374,6 +374,7 @@ define_keywords!(
     TIMEZONE_HOUR,
     TIMEZONE_MINUTE,
     TO,
+    TOP,
     TRAILING,
     TRANSACTION,
     TRANSLATE,
@@ -426,7 +427,7 @@ define_keywords!(
 /// can be parsed unambiguously without looking ahead.
 pub const RESERVED_FOR_TABLE_ALIAS: &[&str] = &[
     // Reserved as both a table and a column alias:
-    WITH, SELECT, WHERE, GROUP, HAVING, ORDER, LIMIT, OFFSET, FETCH, UNION, EXCEPT, INTERSECT,
+    WITH, SELECT, WHERE, GROUP, HAVING, ORDER, TOP, LIMIT, OFFSET, FETCH, UNION, EXCEPT, INTERSECT,
     // Reserved only as a table alias in the `FROM`/`JOIN` clauses:
     ON, JOIN, INNER, CROSS, FULL, LEFT, RIGHT, NATURAL, USING,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1563,7 +1563,7 @@ impl Parser {
         }
 
         let top = if self.parse_keyword("TOP") {
-            self.parse_top()?
+            Some(self.parse_top()?)
         } else {
             None
         };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -783,7 +783,6 @@ impl Parser {
     }
 
     /// Bail out if the current token is not one of the expected keywords, or consume it if it is
-    #[must_use]
     pub fn expect_one_of_keywords(
         &mut self,
         keywords: &[&'static str],

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -522,6 +522,7 @@ fn peeking_take_while(
 #[cfg(test)]
 mod tests {
     use super::super::dialect::GenericDialect;
+    use super::super::dialect::MsSqlDialect;
     use super::*;
 
     #[test]
@@ -781,6 +782,31 @@ mod tests {
         ];
         compare(expected, tokens);
     }
+
+    #[test]
+    fn tokenize_mssql_top() {
+        let sql = "SELECT TOP 5 [bar] FROM foo";
+        //let select = ms_and_generic().verified_query(sql);
+        //assert_eq!(Some(Expr::Value(number("5"))), select.limit);
+        let dialect = MsSqlDialect {};
+        let mut tokenizer = Tokenizer::new(&dialect, sql);
+        let tokens = tokenizer.tokenize().unwrap();
+        let expected = vec![
+            Token::make_keyword("SELECT"),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_keyword("TOP"),
+            Token::Whitespace(Whitespace::Space),
+            Token::Number(String::from("5")),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word("bar", Some('[')),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_keyword("FROM"),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word("foo", None),
+        ];
+        compare(expected, tokens);
+    }
+
 
     fn compare(expected: Vec<Token>, actual: Vec<Token>) {
         //println!("------------------------------");

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -786,8 +786,6 @@ mod tests {
     #[test]
     fn tokenize_mssql_top() {
         let sql = "SELECT TOP 5 [bar] FROM foo";
-        //let select = ms_and_generic().verified_query(sql);
-        //assert_eq!(Some(Expr::Value(number("5"))), select.limit);
         let dialect = MsSqlDialect {};
         let mut tokenizer = Tokenizer::new(&dialect, sql);
         let tokens = tokenizer.tokenize().unwrap();
@@ -806,7 +804,6 @@ mod tests {
         ];
         compare(expected, tokens);
     }
-
 
     fn compare(expected: Vec<Token>, actual: Vec<Token>) {
         //println!("------------------------------");

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -72,32 +72,32 @@ fn parse_mssql_apply_join() {
 fn parse_mssql_top_paren() {
     let sql = "SELECT TOP (5) * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    assert!(!select.percent);
+    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    // assert!(!select.percent);
 }
 
 #[test]
 fn parse_mssql_top_percent() {
     let sql = "SELECT TOP (5) PERCENT * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    assert!(select.percent);
+    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    // assert!(select.percent);
 }
 
 #[test]
 fn parse_mssql_top_with_ties() {
     let sql = "SELECT TOP (5) WITH TIES * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    assert!(select.with_ties);
+    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    //assert!(select.with_ties);
 }
 
 #[test]
 fn parse_mssql_top_percent_with_ties() {
     let sql = "SELECT TOP (5) PERCENT WITH TIES * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    assert!(select.percent);
+    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    // assert!(select.percent);
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -68,6 +68,13 @@ fn parse_mssql_apply_join() {
     );
 }
 
+#[test]
+fn parse_mssql_top() {
+    let sql = "SELECT TOP 5 [bar] FROM foo";
+    let select = ms_and_generic().verified_query(sql);
+    assert_eq!(Some(Expr::Value(number("5"))), select.limit);
+}
+
 fn ms() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MsSqlDialect {})],

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -72,32 +72,36 @@ fn parse_mssql_apply_join() {
 fn parse_mssql_top_paren() {
     let sql = "SELECT TOP (5) * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    // assert!(!select.percent);
+    let top = select.top.unwrap();
+    assert_eq!(Some(Expr::Value(number("5"))), top.quantity);
+    assert!(!top.percent);
 }
 
 #[test]
 fn parse_mssql_top_percent() {
     let sql = "SELECT TOP (5) PERCENT * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    // assert!(select.percent);
+    let top = select.top.unwrap();
+    assert_eq!(Some(Expr::Value(number("5"))), top.quantity);
+    assert!(top.percent);
 }
 
 #[test]
 fn parse_mssql_top_with_ties() {
     let sql = "SELECT TOP (5) WITH TIES * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    //assert!(select.with_ties);
+    let top = select.top.unwrap();
+    assert_eq!(Some(Expr::Value(number("5"))), top.quantity);
+    assert!(top.with_ties);
 }
 
 #[test]
 fn parse_mssql_top_percent_with_ties() {
-    let sql = "SELECT TOP (5) PERCENT WITH TIES * FROM foo";
+    let sql = "SELECT TOP (10) PERCENT WITH TIES * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
-    // assert_eq!(Some(Expr::Value(number("5"))), select.top);
-    // assert!(select.percent);
+    let top = select.top.unwrap();
+    assert_eq!(Some(Expr::Value(number("10"))), top.quantity);
+    assert!(top.percent);
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -69,10 +69,41 @@ fn parse_mssql_apply_join() {
 }
 
 #[test]
+fn parse_mssql_top_paren() {
+    let sql = "SELECT TOP (5) * FROM foo";
+    let select = ms_and_generic().verified_only_select(sql);
+    assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    assert!(!select.percent);
+}
+
+#[test]
+fn parse_mssql_top_percent() {
+    let sql = "SELECT TOP (5) PERCENT * FROM foo";
+    let select = ms_and_generic().verified_only_select(sql);
+    assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    assert!(select.percent);
+}
+
+#[test]
+fn parse_mssql_top_with_ties() {
+    let sql = "SELECT TOP (5) WITH TIES * FROM foo";
+    let select = ms_and_generic().verified_only_select(sql);
+    assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    assert!(select.with_ties);
+}
+
+#[test]
+fn parse_mssql_top_percent_with_ties() {
+    let sql = "SELECT TOP (5) PERCENT WITH TIES * FROM foo";
+    let select = ms_and_generic().verified_only_select(sql);
+    assert_eq!(Some(Expr::Value(number("5"))), select.top);
+    assert!(select.percent);
+}
+
+#[test]
 fn parse_mssql_top() {
-    let sql = "SELECT TOP 5 [bar] FROM foo";
-    let select = ms_and_generic().verified_query(sql);
-    assert_eq!(Some(Expr::Value(number("5"))), select.limit);
+    let sql = "SELECT TOP 5 bar, baz FROM foo";
+    let _ = ms_and_generic().one_statement_parses_to(sql, "SELECT TOP (5) bar, baz FROM foo");
 }
 
 fn ms() -> TestedDialects {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -77,7 +77,7 @@ fn parse_show_columns() {
         Statement::ShowColumns {
             extended: false,
             full: false,
-            table_name: table_name.clone(),
+            table_name: table_name,
             filter: Some(ShowStatementFilter::Where(
                 mysql_and_generic().verified_expr("1 = 2")
             )),


### PR DESCRIPTION
Microsoft SQL Server does not use LIMIT syntax to limit the query result set. Instead, the syntax is `SELECT TOP (numeric expression) [PERCENT] [WITH TIES]`
See: https://docs.microsoft.com/en-us/sql/t-sql/queries/top-transact-sql

This is for Issue #149

This adds a `Top` child struct to the `Select` struct. It may or may not be problematic that `Select` would now have `Top` nested in it, while the outer `Query` struct has a `limit` field, when `TOP` and `LIMIT` have basically the same meaning in different SQL dialects. But since `TOP` is part of the `SELECT` clause in MSSQL's grammar, this seemed to be the most straightforward way to achieve support for it. Open to suggestions!