### PR TITLE
Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ rust:
   - stable
 
 before_script:
+  # Travis installs rust with a non-default "minimal" profile, and advises us
+  # to add clippy manually:
+  - rustup component add clippy
+  # Unfortunately, this method often breaks on the nightly channel, where the
+  # most recent build might not have all the optional components.
+  # We explicitly specify `--profile default` to obtain the most recent nightly
+  # that has rustfmt (we don't care if it's a week old, as we need it only for
+  # an experimental flag):
+  - rustup toolchain install nightly --profile default
+
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
   - export PATH=$HOME/.cargo/bin:$PATH
   # `cargo install` fails if the specified binary is already installed, and
@@ -33,13 +43,9 @@ before_script:
   # rebuilds from scratch, ignoring the cache entirely.
   #
   # [0]: https://github.com/rust-lang/cargo/issues/2082
-  - cargo install cargo-update || echo "cargo-update already installed"
-  - cargo install cargo-travis || echo "cargo-travis already installed"
+  - cargo install cargo-update || echo "cargo-update already installed"  # for `cargo install-update`
+  - cargo install cargo-travis || echo "cargo-travis already installed"  # for `cargo coveralls`
   - cargo install-update -a  # updates cargo-travis, if the cached version is outdated
-  - rustup component add clippy
-  # The license_template_path setting we use to verify copyright headers is
-  # only available on the nightly rustfmt.
-  - rustup toolchain install nightly && rustup component add --toolchain nightly rustfmt
 
 script:
   # Clippy must be run first, as its lints are only triggered during
@@ -50,6 +56,8 @@ script:
   - travis-cargo build
   - travis-cargo test
   - travis-cargo test -- all-features
+  # The license_template_path setting we use to verify copyright headers is
+  # only available on the nightly rustfmt.
   - cargo +nightly fmt -- --check --config-path <(echo 'license_template_path = "HEADER"')
 
 after_success:

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -40,7 +40,7 @@ fn main() {
     println!("Parsing from file '{}' using {:?}", &filename, dialect);
     let contents = fs::read_to_string(&filename)
         .unwrap_or_else(|_| panic!("Unable to read the file {}", &filename));
-    let without_bom = if contents.chars().nth(0).unwrap() as u64 != 0xfeff {
+    let without_bom = if contents.chars().next().unwrap() as u64 != 0xfeff {
         contents.as_str()
     } else {
         let mut chars = contents.chars();


### PR DESCRIPTION
Thanks @eyalleshem for noticing, a clippy update added a new lint, which now fails on Travis:

> iter.next() is equivalent to iter.nth(0), as they both consume the
next element, but is more readable.

https://rust-lang.github.io/rust-clippy/master/index.html#iter_nth_zero

After fixing that, I took advantage of the fact that `rustup` can now install find the nightly with the necessary components instead of complaining that the most recent one is broken.

I also noticed that coverage broke due to a change to the Cargo.lock format and tried to fix that by importing the unreleased version from https://github.com/roblabla/cargo-travis/issues/66 , but that resulted in linking errors, so I dropped it.