### PR TITLE
derive default for GenericDialect

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -12,8 +12,8 @@
 
 use crate::dialect::Dialect;
 
-#[derive(Debug)]
-pub struct GenericDialect {}
+#[derive(Debug, Default)]
+pub struct GenericDialect;
 
 impl Dialect for GenericDialect {
     fn is_identifier_start(&self, ch: char) -> bool {


### PR DESCRIPTION
The motivation behind this changes is that whatever user structure has a field of `GenericDialect` it is trivial to `impl Default` by deriving it like:
```rust
#[derive(Default)]
struct MySqlProcessor {
  dialect: GenericDialect
}
```