### PR TITLE
Add create index and drop index support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check https://github.com/andygrove/sqlparser-rs/commits/master for undocumented 
 - Support Snowflake's `FROM (table_name)` (#155) - thanks @eyalleshem!
 
 ### Added
+- Support basic forms of `CREATE INDEX` and `DROP INDEX` (#167) - thanks @mashuai!
 - Support MSSQL `TOP (<N>) [ PERCENT ] [ WITH TIES ]` (#150) - thanks @alexkyllo!
 - Support MySQL `LIMIT row_count OFFSET offset` (not followed by `ROW` or `ROWS`) and remember which variant was parsed (#158) - thanks @mjibson!
 - Support PostgreSQL `CREATE TABLE IF NOT EXISTS table_name` (#163) - thanks @alex-dukhno!

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -476,6 +476,15 @@ pub enum Statement {
         file_format: Option<FileFormat>,
         location: Option<String>,
     },
+    /// CREATE INDEX
+    CreateIndex {
+        /// index name
+        name: ObjectName,
+        table_name: ObjectName,
+        columns: Vec<Ident>,
+        unique: bool,
+        if_not_exists: bool,
+    },
     /// ALTER TABLE
     AlterTable {
         /// Table name
@@ -655,6 +664,28 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
+            Statement::CreateIndex {
+                name,
+                table_name,
+                columns,
+                unique,
+                if_not_exists,
+            } => {
+                write!(
+                    f,
+                    "CREATE{}INDEX{}{} ON {}({}",
+                    if *unique { " UNIQUE " } else { " " },
+                    if *if_not_exists {
+                        " IF NOT EXISTS "
+                    } else {
+                        " "
+                    },
+                    name,
+                    table_name,
+                    display_separated(columns, ",")
+                )?;
+                write!(f, ");")
+            }
             Statement::AlterTable { name, operation } => {
                 write!(f, "ALTER TABLE {} {}", name, operation)
             }
@@ -819,6 +850,7 @@ impl FromStr for FileFormat {
 pub enum ObjectType {
     Table,
     View,
+    Index,
 }
 
 impl fmt::Display for ObjectType {
@@ -826,6 +858,7 @@ impl fmt::Display for ObjectType {
         f.write_str(match self {
             ObjectType::Table => "TABLE",
             ObjectType::View => "VIEW",
+            ObjectType::Index => "INDEX",
         })
     }
 }

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -200,6 +200,7 @@ define_keywords!(
     IDENTITY,
     IF,
     IN,
+    INDEX,
     INDICATOR,
     INNER,
     INOUT,
@@ -420,8 +421,7 @@ define_keywords!(
     WORK,
     YEAR,
     ZONE,
-    END_EXEC = "END-EXEC",
-    INDEX
+    END_EXEC = "END-EXEC"
 );
 
 /// These keywords can't be used as a table alias, so that `FROM table_name alias`

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -420,7 +420,8 @@ define_keywords!(
     WORK,
     YEAR,
     ZONE,
-    END_EXEC = "END-EXEC"
+    END_EXEC = "END-EXEC",
+    INDEX
 );
 
 /// These keywords can't be used as a table alias, so that `FROM table_name alias`

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -943,9 +943,7 @@ impl Parser {
         let index_name = self.parse_object_name()?;
         self.expect_keyword("ON")?;
         let table_name = self.parse_object_name()?;
-        self.expect_token(&Token::LParen)?;
-        let columns = self.parse_comma_separated(Parser::parse_identifier)?;
-        self.expect_token(&Token::RParen)?;
+        let columns = self.parse_parenthesized_column_list(Mandatory)?;
         Ok(Statement::CreateIndex {
             name: index_name,
             table_name,


### PR DESCRIPTION
This PR adds support for:

    CREATE [ UNIQUE ] INDEX [ IF NOT EXISTS ]
        <index_name>
        ON <table_name>
        ( col_name [, ...] )

    DROP INDEX <index_name>