### PR TITLE
Add support for "on delete cascade" column option

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -156,10 +156,9 @@ pub enum ColumnOption {
     },
     /// A referential integrity constraint (`[FOREIGN KEY REFERENCES
     /// <foreign_table> (<referred_columns>)
-    /// [ON DELETE <referential_action>]
-    /// [ON UPDATE <referential_action>]`).
-    ///
-    /// The `ON DELETE` option may be placed after the `ON UPDATE` option.
+    /// { [ON DELETE <referential_action>] [ON UPDATE <referential_action>] |
+    ///   [ON UPDATE <referential_action>] [ON DELETE <referential_action>]
+    /// }`).
     ForeignKey {
         foreign_table: ObjectName,
         referred_columns: Vec<Ident>,

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -187,7 +187,7 @@ impl fmt::Display for ColumnOption {
                 on_update,
             } => {
                 write!(f, "REFERENCES {}", foreign_table)?;
-                if referred_columns.len() > 0 {
+                if ! referred_columns.is_empty() {
                     write!(f, " ({})", display_comma_separated(referred_columns))?;
                 }
                 if let Some(action) = on_delete {

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -156,8 +156,8 @@ pub enum ColumnOption {
     },
     /// A referential integrity constraint (`[FOREIGN KEY REFERENCES
     /// <foreign_table> (<referred_columns>)
-    /// [ON DELETE <reference_change_action>]
-    /// [ON UPDATE <reference_change_action>]`).
+    /// [ON DELETE <referential_action>]
+    /// [ON UPDATE <referential_action>]`).
     ///
     /// The `ON DELETE` option may be placed after the `ON UPDATE` option.
     ForeignKey {
@@ -216,7 +216,7 @@ fn display_constraint_name<'a>(name: &'a Option<Ident>) -> impl fmt::Display + '
     ConstraintName(name)
 }
 
-/// `<reference_change_action> =
+/// `<referential_action> =
 /// { RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT }`
 ///
 /// Used in foreign key constraints in `ON UPDATE` and `ON DELETE` options.

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -187,7 +187,7 @@ impl fmt::Display for ColumnOption {
                 on_update,
             } => {
                 write!(f, "REFERENCES {}", foreign_table)?;
-                if ! referred_columns.is_empty() {
+                if !referred_columns.is_empty() {
                     write!(f, " ({})", display_comma_separated(referred_columns))?;
                 }
                 if let Some(action) = on_delete {

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -155,10 +155,16 @@ pub enum ColumnOption {
         is_primary: bool,
     },
     /// A referential integrity constraint (`[FOREIGN KEY REFERENCES
-    /// <foreign_table> (<referred_columns>)`).
+    /// <foreign_table> (<referred_columns>)
+    /// [ON DELETE <reference_change_action>]
+    /// [ON UPDATE <reference_change_action>]`).
+    ///
+    /// The `ON DELETE` option may be placed after the `ON UPDATE` option.
     ForeignKey {
         foreign_table: ObjectName,
         referred_columns: Vec<Ident>,
+        on_delete: Option<ReferentialAction>,
+        on_update: Option<ReferentialAction>,
     },
     // `CHECK (<expr>)`
     Check(Expr),
@@ -177,12 +183,21 @@ impl fmt::Display for ColumnOption {
             ForeignKey {
                 foreign_table,
                 referred_columns,
-            } => write!(
-                f,
-                "REFERENCES {} ({})",
-                foreign_table,
-                display_comma_separated(referred_columns)
-            ),
+                on_delete,
+                on_update,
+            } => {
+                write!(f, "REFERENCES {}", foreign_table)?;
+                if referred_columns.len() > 0 {
+                    write!(f, " ({})", display_comma_separated(referred_columns))?;
+                }
+                if let Some(action) = on_delete {
+                    write!(f, " ON DELETE {}", action)?;
+                }
+                if let Some(action) = on_update {
+                    write!(f, " ON UPDATE {}", action)?;
+                }
+                Ok(())
+            }
             Check(expr) => write!(f, "CHECK ({})", expr),
         }
     }
@@ -199,4 +214,29 @@ fn display_constraint_name<'a>(name: &'a Option<Ident>) -> impl fmt::Display + '
         }
     }
     ConstraintName(name)
+}
+
+/// `<reference_change_action> =
+/// { RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT }`
+///
+/// Used in foreign key constraints in `ON UPDATE` and `ON DELETE` options.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ReferentialAction {
+    Restrict,
+    Cascade,
+    SetNull,
+    NoAction,
+    SetDefault,
+}
+
+impl fmt::Display for ReferentialAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            ReferentialAction::Restrict => "RESTRICT",
+            ReferentialAction::Cascade => "CASCADE",
+            ReferentialAction::SetNull => "SET NULL",
+            ReferentialAction::NoAction => "NO ACTION",
+            ReferentialAction::SetDefault => "SET DEFAULT",
+        })
+    }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -23,6 +23,7 @@ use std::fmt;
 pub use self::data_type::DataType;
 pub use self::ddl::{
     AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef, TableConstraint,
+    ReferentialAction,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -22,8 +22,8 @@ use std::fmt;
 
 pub use self::data_type::DataType;
 pub use self::ddl::{
-    AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef, TableConstraint,
-    ReferentialAction,
+    AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef, ReferentialAction,
+    TableConstraint,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -51,6 +51,7 @@ macro_rules! define_keywords {
 
 define_keywords!(
     ABS,
+    ACTION,
     ADD,
     ASC,
     ALL,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1017,6 +1017,8 @@ impl Parser {
             ColumnOption::Unique { is_primary: false }
         } else if self.parse_keyword("REFERENCES") {
             let foreign_table = self.parse_object_name()?;
+            // PostgreSQL allows omitting the column list and
+            // uses the primary key column of the foreign table by default
             let referred_columns = self.parse_parenthesized_column_list(Optional)?;
             let mut on_delete = None;
             let mut on_update = None;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1023,14 +1023,14 @@ impl Parser {
             while self.parse_keyword("ON") {
                 if self.parse_keyword("DELETE") {
                     if on_delete == None {
-                        on_delete = Some(self.parse_reference_change_action()?);
+                        on_delete = Some(self.parse_referential_action()?);
                     } else {
                         return self
                             .expected("ON DELETE option not more than once", self.peek_token());
                     }
                 } else if self.parse_keyword("UPDATE") {
                     if on_update == None {
-                        on_update = Some(self.parse_reference_change_action()?);
+                        on_update = Some(self.parse_referential_action()?);
                     } else {
                         return self
                             .expected("ON UPDATE option not more than once", self.peek_token());
@@ -1055,7 +1055,7 @@ impl Parser {
         Ok(ColumnOptionDef { name, option })
     }
 
-    pub fn parse_reference_change_action(&mut self) -> Result<ReferentialAction, ParserError> {
+    pub fn parse_referential_action(&mut self) -> Result<ReferentialAction, ParserError> {
         if self.parse_keyword("RESTRICT") {
             Ok(ReferentialAction::Restrict)
         } else if self.parse_keyword("CASCADE") {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1022,21 +1022,13 @@ impl Parser {
             let referred_columns = self.parse_parenthesized_column_list(Optional)?;
             let mut on_delete = None;
             let mut on_update = None;
-            while self.parse_keyword("ON") {
-                if self.parse_keyword("DELETE") {
-                    if on_delete == None {
-                        on_delete = Some(self.parse_referential_action()?);
-                    } else {
-                        return self
-                            .expected("ON DELETE option not more than once", self.peek_token());
-                    }
-                } else if self.parse_keyword("UPDATE") {
-                    if on_update == None {
-                        on_update = Some(self.parse_referential_action()?);
-                    } else {
-                        return self
-                            .expected("ON UPDATE option not more than once", self.peek_token());
-                    }
+            loop {
+                if on_delete.is_none() && self.parse_keywords(vec!["ON", "DELETE"]) {
+                    on_delete = Some(self.parse_referential_action()?);
+                } else if on_update.is_none() && self.parse_keywords(vec!["ON", "UPDATE"]) {
+                    on_update = Some(self.parse_referential_action()?);
+                } else {
+                    break;
                 }
             }
             ColumnOption::ForeignKey {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1017,8 +1017,7 @@ impl Parser {
             ColumnOption::Unique { is_primary: false }
         } else if self.parse_keyword("REFERENCES") {
             let foreign_table = self.parse_object_name()?;
-            let referred_columns =
-                self.parse_parenthesized_column_list(Optional)?;
+            let referred_columns = self.parse_parenthesized_column_list(Optional)?;
             let mut on_delete = None;
             let mut on_update = None;
             while self.parse_keyword("ON") {
@@ -1026,19 +1025,15 @@ impl Parser {
                     if on_delete == None {
                         on_delete = Some(self.parse_reference_change_action()?);
                     } else {
-                        return self.expected(
-                            "ON DELETE option not more than once",
-                            self.peek_token()
-                        );
+                        return self
+                            .expected("ON DELETE option not more than once", self.peek_token());
                     }
                 } else if self.parse_keyword("UPDATE") {
                     if on_update == None {
                         on_update = Some(self.parse_reference_change_action()?);
                     } else {
-                        return self.expected(
-                            "ON UPDATE option not more than once",
-                            self.peek_token()
-                        );
+                        return self
+                            .expected("ON UPDATE option not more than once", self.peek_token());
                     }
                 }
             }
@@ -1061,13 +1056,21 @@ impl Parser {
     }
 
     pub fn parse_reference_change_action(&mut self) -> Result<ReferentialAction, ParserError> {
-        if self.parse_keyword("RESTRICT") { Ok(ReferentialAction::Restrict) }
-        else if self.parse_keyword("CASCADE") { Ok(ReferentialAction::Cascade) }
-        else if self.parse_keywords(vec!["SET", "NULL"]) { Ok(ReferentialAction::SetNull) }
-        else if self.parse_keywords(vec!["NO", "ACTION"]) { Ok(ReferentialAction::NoAction) }
-        else if self.parse_keywords(vec!["SET", "DEFAULT"]) { Ok(ReferentialAction::SetDefault) }
-        else {
-            self.expected("one of RESTRICT, CASCADE, SET NULL, NO ACTION or SET DEFAULT", self.peek_token())
+        if self.parse_keyword("RESTRICT") {
+            Ok(ReferentialAction::Restrict)
+        } else if self.parse_keyword("CASCADE") {
+            Ok(ReferentialAction::Cascade)
+        } else if self.parse_keywords(vec!["SET", "NULL"]) {
+            Ok(ReferentialAction::SetNull)
+        } else if self.parse_keywords(vec!["NO", "ACTION"]) {
+            Ok(ReferentialAction::NoAction)
+        } else if self.parse_keywords(vec!["SET", "DEFAULT"]) {
+            Ok(ReferentialAction::SetDefault)
+        } else {
+            self.expected(
+                "one of RESTRICT, CASCADE, SET NULL, NO ACTION or SET DEFAULT",
+                self.peek_token(),
+            )
         }
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -990,17 +990,15 @@ fn parse_create_table() {
                         name: "ref2".into(),
                         data_type: DataType::Int,
                         collation: None,
-                        options: vec![
-                            ColumnOptionDef {
-                                name: None,
-                                option: ColumnOption::ForeignKey {
-                                    foreign_table: ObjectName(vec!["othertable2".into()]),
-                                    referred_columns: vec![],
-                                    on_delete: Some(ReferentialAction::Cascade),
-                                    on_update: Some(ReferentialAction::NoAction),
-                                }
-                            },
-                        ]
+                        options: vec![ColumnOptionDef {
+                            name: None,
+                            option: ColumnOption::ForeignKey {
+                                foreign_table: ObjectName(vec!["othertable2".into()]),
+                                referred_columns: vec![],
+                                on_delete: Some(ReferentialAction::Cascade),
+                                on_update: Some(ReferentialAction::NoAction),
+                            }
+                        },]
                     }
                 ]
             );

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -893,7 +893,9 @@ fn parse_create_table() {
                lat DOUBLE NULL,\
                lng DOUBLE,
                constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0),
-               ref INT REFERENCES othertable (a, b))";
+               ref INT REFERENCES othertable (a, b),\
+               ref2 INT references othertable2 on delete cascade on update no action\
+               )";
     let ast = one_statement_parses_to(
         sql,
         "CREATE TABLE uk_cities (\
@@ -901,7 +903,8 @@ fn parse_create_table() {
          lat double NULL, \
          lng double, \
          constrained int NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), \
-         ref int REFERENCES othertable (a, b))",
+         ref int REFERENCES othertable (a, b), \
+         ref2 int REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION)",
     );
     match ast {
         Statement::CreateTable {
@@ -978,8 +981,26 @@ fn parse_create_table() {
                             option: ColumnOption::ForeignKey {
                                 foreign_table: ObjectName(vec!["othertable".into()]),
                                 referred_columns: vec!["a".into(), "b".into(),],
+                                on_delete: None,
+                                on_update: None,
                             }
                         }]
+                    },
+                    ColumnDef {
+                        name: "ref2".into(),
+                        data_type: DataType::Int,
+                        collation: None,
+                        options: vec![
+                            ColumnOptionDef {
+                                name: None,
+                                option: ColumnOption::ForeignKey {
+                                    foreign_table: ObjectName(vec!["othertable2".into()]),
+                                    referred_columns: vec![],
+                                    on_delete: Some(ReferentialAction::Cascade),
+                                    on_update: Some(ReferentialAction::NoAction),
+                                }
+                            },
+                        ]
                     }
                 ]
             );


### PR DESCRIPTION
This introduces some breaking changes.

Is it a good idea to have a lifetime parameter in `Parser`?