### PR TITLE
Fix GitHub CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,14 +4,13 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
     - name: Setup Rust
       run: |
-        rustup toolchain install nightly && rustup component add --toolchain nightly rustfmt
+        rustup toolchain install nightly --profile default
         rustup toolchain install stable
         rustup override set stable
     # Clippy must be run first, as its lints are only triggered during


### PR DESCRIPTION
This ports the changes made to travis configuration in #159 to GitHub actions. This should fix the build failures due to unavailable rustfmt on certain nightlies, like today's