### PR TITLE
Support bitwise and, or, xor

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -49,6 +49,9 @@ pub enum BinaryOperator {
     Or,
     Like,
     NotLike,
+    BitwiseOr,
+    BitwiseAnd,
+    BitwiseXor,
 }
 
 impl fmt::Display for BinaryOperator {
@@ -70,6 +73,9 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::Or => "OR",
             BinaryOperator::Like => "LIKE",
             BinaryOperator::NotLike => "NOT LIKE",
+            BinaryOperator::BitwiseOr => "|",
+            BinaryOperator::BitwiseAnd => "&",
+            BinaryOperator::BitwiseXor => "^",
         })
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -578,6 +578,9 @@ impl Parser {
             Token::Mult => Some(BinaryOperator::Multiply),
             Token::Mod => Some(BinaryOperator::Modulus),
             Token::StringConcat => Some(BinaryOperator::StringConcat),
+            Token::Pipe => Some(BinaryOperator::BitwiseOr),
+            Token::Caret => Some(BinaryOperator::BitwiseXor),
+            Token::Ampersand => Some(BinaryOperator::BitwiseAnd),
             Token::Div => Some(BinaryOperator::Divide),
             Token::Word(ref k) => match k.keyword.as_ref() {
                 "AND" => Some(BinaryOperator::And),
@@ -708,6 +711,9 @@ impl Parser {
                 Token::Eq | Token::Lt | Token::LtEq | Token::Neq | Token::Gt | Token::GtEq => {
                     Ok(20)
                 }
+                Token::Pipe => Ok(21),
+                Token::Caret => Ok(22),
+                Token::Ampersand => Ok(23),
                 Token::Plus | Token::Minus => Ok(Self::PLUS_MINUS_PREC),
                 Token::Mult | Token::Div | Token::Mod | Token::StringConcat => Ok(40),
                 Token::DoubleColon => Ok(50),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -681,6 +681,27 @@ fn parse_string_agg() {
 }
 
 #[test]
+fn parse_bitwise_ops() {
+    let bitwise_ops = vec![
+        ("^", BinaryOperator::BitwiseXor),
+        ("|", BinaryOperator::BitwiseOr),
+        ("&", BinaryOperator::BitwiseAnd),
+    ];
+
+    for (str_op, op) in bitwise_ops.iter() {
+        let select = verified_only_select(&format!("SELECT a {} b", &str_op));
+        assert_eq!(
+            SelectItem::UnnamedExpr(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("a"))),
+                op: op.clone(),
+                right: Box::new(Expr::Identifier(Ident::new("b"))),
+            }),
+            select.projection[0]
+        );
+    }
+}
+
+#[test]
 fn parse_between() {
     fn chk(negated: bool) {
         let sql = &format!(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -682,13 +682,13 @@ fn parse_string_agg() {
 
 #[test]
 fn parse_bitwise_ops() {
-    let bitwise_ops = vec![
+    let bitwise_ops = &[
         ("^", BinaryOperator::BitwiseXor),
         ("|", BinaryOperator::BitwiseOr),
         ("&", BinaryOperator::BitwiseAnd),
     ];
 
-    for (str_op, op) in bitwise_ops.iter() {
+    for (str_op, op) in bitwise_ops {
         let select = verified_only_select(&format!("SELECT a {} b", &str_op));
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::BinaryOp {


### PR DESCRIPTION
Supporting bitwise and, or, xor.

Operator precedence is coming from:

https://cloud.google.com/bigquery/docs/reference/standard-sql/operators