### PR TITLE
Accept &str in `Parse::parse_sql`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ let sql = "SELECT a, b, 123, myfunc(b) \
 
 let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...
 
-let ast = Parser::parse_sql(&dialect, sql.to_string()).unwrap();
+let ast = Parser::parse_sql(&dialect, sql).unwrap();
 
 println!("AST: {:?}", ast);
 ```

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -45,7 +45,7 @@ fn main() {
         chars.next();
         chars.as_str()
     };
-    let parse_result = Parser::parse_sql(&*dialect, without_bom.to_owned());
+    let parse_result = Parser::parse_sql(&*dialect, without_bom);
     match parse_result {
         Ok(statements) => {
             println!(

--- a/examples/parse_select.rs
+++ b/examples/parse_select.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let dialect = GenericDialect {};
 
-    let ast = Parser::parse_sql(&dialect, sql.to_string()).unwrap();
+    let ast = Parser::parse_sql(&dialect, sql).unwrap();
 
     println!("AST: {:?}", ast);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!            WHERE a > b AND b < 100 \
 //!            ORDER BY a DESC, b";
 //!
-//! let ast = Parser::parse_sql(&dialect, sql.to_string()).unwrap();
+//! let ast = Parser::parse_sql(&dialect, sql).unwrap();
 //!
 //! println!("AST: {:?}", ast);
 //! ```

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -82,7 +82,7 @@ impl Parser {
     }
 
     /// Parse a SQL statement and produce an Abstract Syntax Tree (AST)
-    pub fn parse_sql(dialect: &dyn Dialect, sql: String) -> Result<Vec<Statement>, ParserError> {
+    pub fn parse_sql(dialect: &dyn Dialect, sql: &str) -> Result<Vec<Statement>, ParserError> {
         let mut tokenizer = Tokenizer::new(dialect, &sql);
         let tokens = tokenizer.tokenize()?;
         let mut parser = Parser::new(tokens);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -58,9 +58,9 @@ impl TestedDialects {
     }
 
     pub fn parse_sql_statements(&self, sql: &str) -> Result<Vec<Statement>, ParserError> {
-        self.one_of_identical_results(|dialect| Parser::parse_sql(dialect, sql.to_string()))
+        self.one_of_identical_results(|dialect| Parser::parse_sql(dialect, &sql))
         // To fail the `ensure_multiple_dialects_are_tested` test:
-        // Parser::parse_sql(&**self.dialects.first().unwrap(), sql.to_string())
+        // Parser::parse_sql(&**self.dialects.first().unwrap(), sql)
     }
 
     /// Ensures that `sql` parses as a single statement, optionally checking


### PR DESCRIPTION
It is more generic to accept a `&str` than a `String` in an API, and avoids having to convert a the string to a `String` when not needed, avoiding a copy.