### PR TITLE
alter interval to support postgres syntax

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -526,7 +526,13 @@ impl Parser {
         // Note that PostgreSQL allows omitting the qualifier, so we provide
         // this more general implemenation.
         let leading_field = match self.peek_token() {
-            Some(Token::Word(..)) => Some(self.parse_date_time_field()?),
+            Some(Token::Word(kw))
+                if ["YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"]
+                    .iter()
+                    .any(|d| kw.keyword == *d) =>
+            {
+                Some(self.parse_date_time_field()?)
+            }
             _ => None,
         };
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -523,12 +523,15 @@ impl Parser {
         // Following the string literal is a qualifier which indicates the units
         // of the duration specified in the string literal.
         //
-        // Note that PostgreSQL allows omitting the qualifier, but we currently
-        // require at least the leading field, in accordance with the ANSI spec.
-        let leading_field = self.parse_date_time_field()?;
+        // Note that PostgreSQL allows omitting the qualifier, so we provide
+        // this more general implemenation.
+        let leading_field = match self.peek_token() {
+            Some(Token::Word(..)) => Some(self.parse_date_time_field()?),
+            _ => None,
+        };
 
         let (leading_precision, last_field, fsec_precision) =
-            if leading_field == DateTimeField::Second {
+            if leading_field == Some(DateTimeField::Second) {
                 // SQL mandates special syntax for `SECOND TO SECOND` literals.
                 // Instead of
                 //     `SECOND [(<leading precision>)] TO SECOND[(<fractional seconds precision>)]`

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1558,6 +1558,11 @@ fn parse_literal_interval() {
     verified_only_select("SELECT INTERVAL '1' HOUR TO SECOND");
     verified_only_select("SELECT INTERVAL '1' MINUTE TO SECOND");
     verified_only_select("SELECT INTERVAL '1 YEAR'");
+    verified_only_select("SELECT INTERVAL '1 YEAR' AS one_year");
+    one_statement_parses_to(
+        "SELECT INTERVAL '1 YEAR' one_year",
+        "SELECT INTERVAL '1 YEAR' AS one_year",
+    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1459,7 +1459,7 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "1-1".into(),
-            leading_field: DateTimeField::Year,
+            leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
             fractional_seconds_precision: None,
@@ -1472,7 +1472,7 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "01:01.01".into(),
-            leading_field: DateTimeField::Minute,
+            leading_field: Some(DateTimeField::Minute),
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
             fractional_seconds_precision: Some(5),
@@ -1485,7 +1485,7 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "1".into(),
-            leading_field: DateTimeField::Second,
+            leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
             fractional_seconds_precision: Some(4),
@@ -1498,7 +1498,7 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "10".into(),
-            leading_field: DateTimeField::Hour,
+            leading_field: Some(DateTimeField::Hour),
             leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
@@ -1511,8 +1511,21 @@ fn parse_literal_interval() {
     assert_eq!(
         &Expr::Value(Value::Interval {
             value: "10".into(),
-            leading_field: DateTimeField::Hour,
+            leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
+            last_field: None,
+            fractional_seconds_precision: None,
+        }),
+        expr_from_projection(only(&select.projection)),
+    );
+
+    let sql = "SELECT INTERVAL '1 DAY'";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Value(Value::Interval {
+            value: "1 DAY".into(),
+            leading_field: None,
+            leading_precision: None,
             last_field: None,
             fractional_seconds_precision: None,
         }),
@@ -1544,6 +1557,7 @@ fn parse_literal_interval() {
     verified_only_select("SELECT INTERVAL '1' HOUR TO MINUTE");
     verified_only_select("SELECT INTERVAL '1' HOUR TO SECOND");
     verified_only_select("SELECT INTERVAL '1' MINUTE TO SECOND");
+    verified_only_select("SELECT INTERVAL '1 YEAR'");
 }
 
 #[test]


### PR DESCRIPTION
This patch updates our INTERVAL implementation such that the Postgres
and Redshfit variation of the syntax is supported: namely that leading
field is optional.

Fixes #177.