### PR TITLE
rework github actions for code coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           components: clippy
       - uses: actions/checkout@v2
-      - run: cargo clippy --all-targets -- -D clippy::all --all-features
+      - run: cargo clippy -- --all-targets --all-features -- -D warnings
 
   compile:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Test
-      run: cargo test --all-features
+      run: cargo test -- all-features
     - name: Coverage
       if: matrix.rust == 'stable'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         with:
           components: rustfmt
+          # Note that `nightly` is required for `license_template_path`, as it's an unstable feature.
           rust-version: nightly
       - uses: actions/checkout@v2
       - run: cargo fmt -- --check --config-path <(echo 'license_template_path = "HEADER"')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           components: clippy
       - uses: actions/checkout@v2
-      - run: cargo clippy -- --all-targets --all-features -- -D warnings
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,28 +3,58 @@ name: Rust
 on: [push]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
 
+  codestyle:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+      - name: Set up Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          components: rustfmt
+          rust-version: nightly
+      - uses: actions/checkout@v2
+      - run: cargo fmt -- --check --config-path <(echo 'license_template_path = "HEADER"')
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          components: clippy
+      - uses: actions/checkout@v2
+      - run: cargo clippy --all-targets -- -D clippy::all
+
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Rust
+        uses: hecrj/setup-rust-action@v1
+      - uses: actions/checkout@master
+      - run: cargo check --all
+
+  test:
+    needs: [codestyle, lint, compile]
+    strategy:
+      matrix:
+        rust: [stable, beta, nightly]
+    runs-on: ubuntu-latest
+    steps:
     - name: Setup Rust
+      uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Test
+      run: cargo test
+    - name: Coverage
+      if: matrix.rust == 'stable'
       run: |
-        rustup toolchain install nightly --profile default
-        rustup toolchain install stable
-        rustup override set stable
-    # Clippy must be run first, as its lints are only triggered during
-    # compilation. Put another way: after a successful `cargo build`, `cargo
-    # clippy` is guaranteed to produce no results. This bug is known upstream:
-    # https://github.com/rust-lang/rust-clippy/issues/2604.
-#    - name: Clippy
-#      run: cargo clippy -- --all-targets --all-features -- -D warnings
-    - name: Check formatting
-      run: |
-        cargo +nightly fmt -- --check --config-path <(echo 'license_template_path = "HEADER"')
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run tests for all features
-      run: cargo test --verbose -- all-features
+        # Tarpaulin interoperates with CI services, however Actions is not
+        # currently supported. As a workaround, we can pretend to be Travis.
+        export TRAVIS_JOB_ID=${GITHUB_SHA}
+        export TRAVIS_PULL_REQUEST=false
+        export TRAVIS_BRANCH=${GITHUB_REF##*/}
+        cargo install cargo-tarpaulin
+        cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Rust
         uses: hecrj/setup-rust-action@v1
       - uses: actions/checkout@master
-      - run: cargo check --all
+      - run: cargo check --all-targets --all-features
 
   test:
     needs: [codestyle, lint, compile]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,8 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         with:
           components: rustfmt
-          # Note that `nightly` is required for `license_template_path`, as it's an unstable feature.
+          # Note that `nightly` is required for `license_template_path`, as
+          # it's an unstable feature.
           rust-version: nightly
       - uses: actions/checkout@v2
       - run: cargo fmt -- --check --config-path <(echo 'license_template_path = "HEADER"')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Test
-      run: cargo test -- all-features
+      run: cargo test --all-features
     - name: Coverage
       if: matrix.rust == 'stable'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,12 @@ jobs:
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
+    - name: Install Tarpaulin
+      uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-tarpaulin
+          version: 0.13.3
+          use-tool-cache: true
     - name: Checkout
       uses: actions/checkout@v2
     - name: Test
@@ -57,5 +63,4 @@ jobs:
         export TRAVIS_JOB_ID=${GITHUB_SHA}
         export TRAVIS_PULL_REQUEST=false
         export TRAVIS_BRANCH=${GITHUB_REF##*/}
-        cargo install cargo-tarpaulin
         cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,10 +47,10 @@ jobs:
         rust-version: ${{ matrix.rust }}
     - name: Install Tarpaulin
       uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-tarpaulin
-          version: 0.13.3
-          use-tool-cache: true
+      with:
+        crate: cargo-tarpaulin
+        version: 0.13.3
+        use-tool-cache: true
     - name: Checkout
       uses: actions/checkout@v2
     - name: Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,6 @@ jobs:
       - run: cargo check --all-targets --all-features
 
   test:
-    needs: [codestyle, lint, compile]
     strategy:
       matrix:
         rust: [stable, beta, nightly]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,10 +57,9 @@ jobs:
       run: cargo test --all-features
     - name: Coverage
       if: matrix.rust == 'stable'
-      run: |
-        # Tarpaulin interoperates with CI services, however Actions is not
-        # currently supported. As a workaround, we can pretend to be Travis.
-        export TRAVIS_JOB_ID=${GITHUB_SHA}
-        export TRAVIS_PULL_REQUEST=false
-        export TRAVIS_BRANCH=${GITHUB_REF##*/}
-        cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+      run: cargo tarpaulin -o Lcov --output-dir ./coverage
+    - name: Coveralls
+      if: matrix.rust == 'stable'
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           components: clippy
       - uses: actions/checkout@v2
-      - run: cargo clippy --all-targets -- -D clippy::all
+      - run: cargo clippy --all-targets -- -D clippy::all --all-features
 
   compile:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Test
-      run: cargo test
+      run: cargo test --all-features
     - name: Coverage
       if: matrix.rust == 'stable'
       run: |


### PR DESCRIPTION
This reworks our GitHub Actions workflow to include code coverage via
tarpaulin. Note that this is essentially directly lifted from the
again[1] crate's methodology.

Fixes #164.

[1]
https://github.com/softprops/again/blob/dd5f0013533e28f803b282ebc281e9525ca64d86/.github/workflows/main.yml