### PR TITLE
support general typed string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ Check https://github.com/andygrove/sqlparser-rs/commits/master for undocumented 
 - Change `Ident` (previously a simple `String`) to store the parsed (unquoted) `value` of the identifier and the `quote_style` separately (#143) - thanks @apparebit!
 - Support Snowflake's `FROM (table_name)` (#155) - thanks @eyalleshem!
 - Add line and column number to TokenizerError (#194) - thanks @Dandandan!
+- Use Token::EOF instead of Option<Token> (#195)
 - Make the units keyword following `INTERVAL '...'` optional (#184) - thanks @maxcountryman!
+- Generalize `DATE`/`TIME`/`TIMESTAMP` literals representation in the AST (`TypedString { data_type, value }`) and allow `DATE` and other keywords to be used as identifiers when not followed by a string (#187) - thanks @maxcountryman!
 
 ### Added
 - Support MSSQL `TOP (<N>) [ PERCENT ] [ WITH TIES ]` (#150) - thanks @alexkyllo!
@@ -26,6 +28,7 @@ Check https://github.com/andygrove/sqlparser-rs/commits/master for undocumented 
 - Support `LISTAGG()` (#174) - thanks @maxcountryman!
 - Support the string concatentation operator `||` (#178) - thanks @Dandandan!
 - Support bitwise AND (`&`), OR (`|`), XOR (`^`) (#181) - thanks @Dandandan!
+- Add serde support to AST structs and enums (#196) - thanks @panarch!
 
 ### Fixed
 - Report an error for unterminated string literals (#165)

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -210,6 +210,10 @@ pub enum Expr {
     Nested(Box<Expr>),
     /// A literal value, such as string, number, date or NULL
     Value(Value),
+    /// A constant of form `<data_type> 'value'`.
+    /// This can represent ANSI SQL `DATE`, `TIME`, and `TIMESTAMP` literals (such as `DATE '2020-01-01'`),
+    /// as well as constants of other types (a non-standard PostgreSQL extension).
+    TypedString { data_type: DataType, value: String },
     /// Scalar function call e.g. `LEFT(foo, 5)`
     Function(Function),
     /// `CASE [<operand>] WHEN <condition> THEN <result> ... [ELSE <result>] END`
@@ -284,6 +288,10 @@ impl fmt::Display for Expr {
             Expr::Collate { expr, collation } => write!(f, "{} COLLATE {}", expr, collation),
             Expr::Nested(ast) => write!(f, "({})", ast),
             Expr::Value(v) => write!(f, "{}", v),
+            Expr::TypedString { data_type, value } => {
+                write!(f, "{}", data_type)?;
+                write!(f, " '{}'", &value::escape_single_quote_string(value))
+            }
             Expr::Function(fun) => write!(f, "{}", fun),
             Expr::Case {
                 operand,

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -33,12 +33,6 @@ pub enum Value {
     HexStringLiteral(String),
     /// Boolean value true or false
     Boolean(bool),
-    /// `DATE '...'` literals
-    Date(String),
-    /// `TIME '...'` literals
-    Time(String),
-    /// `TIMESTAMP '...'` literals
-    Timestamp(String),
     /// INTERVAL literals, roughly in the following format:
     /// `INTERVAL '<value>' [ <leading_field> [ (<leading_precision>) ] ]
     /// [ TO <last_field> [ (<fractional_seconds_precision>) ] ]`,
@@ -70,9 +64,6 @@ impl fmt::Display for Value {
             Value::NationalStringLiteral(v) => write!(f, "N'{}'", v),
             Value::HexStringLiteral(v) => write!(f, "X'{}'", v),
             Value::Boolean(v) => write!(f, "{}", v),
-            Value::Date(v) => write!(f, "DATE '{}'", escape_single_quote_string(v)),
-            Value::Time(v) => write!(f, "TIME '{}'", escape_single_quote_string(v)),
-            Value::Timestamp(v) => write!(f, "TIMESTAMP '{}'", escape_single_quote_string(v)),
             Value::Interval {
                 value,
                 leading_field: Some(DateTimeField::Second),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -414,6 +414,19 @@ fn parse_null_in_select() {
 }
 
 #[test]
+fn parse_select_with_date_column_name() {
+    let sql = "SELECT date";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Identifier(Ident {
+            value: "date".into(),
+            quote_style: None
+        }),
+        expr_from_projection(only(&select.projection)),
+    );
+}
+
+#[test]
 fn parse_escaped_single_quote_string_predicate() {
     use self::BinaryOperator::*;
     let sql = "SELECT id, fname, lname FROM customer \
@@ -1424,30 +1437,39 @@ fn parse_literal_string() {
 
 #[test]
 fn parse_literal_date() {
-    let sql = "SELECT DATE '1999-01-01'";
+    let sql = "SELECT date '1999-01-01'";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Value(Value::Date("1999-01-01".into())),
+        &Expr::TypedString {
+            data_type: DataType::Date,
+            value: "1999-01-01".into()
+        },
         expr_from_projection(only(&select.projection)),
     );
 }
 
 #[test]
 fn parse_literal_time() {
-    let sql = "SELECT TIME '01:23:34'";
+    let sql = "SELECT time '01:23:34'";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Value(Value::Time("01:23:34".into())),
+        &Expr::TypedString {
+            data_type: DataType::Time,
+            value: "01:23:34".into()
+        },
         expr_from_projection(only(&select.projection)),
     );
 }
 
 #[test]
 fn parse_literal_timestamp() {
-    let sql = "SELECT TIMESTAMP '1999-01-01 01:23:34'";
+    let sql = "SELECT timestamp '1999-01-01 01:23:34'";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Value(Value::Timestamp("1999-01-01 01:23:34".into())),
+        &Expr::TypedString {
+            data_type: DataType::Timestamp,
+            value: "1999-01-01 01:23:34".into()
+        },
         expr_from_projection(only(&select.projection)),
     );
 }


### PR DESCRIPTION
This is a direct port of MaterializeInc/materialize#3146. It provides
support for e.g. Postgres syntax where any string literal may be
preceded by a type name.

Fixes #168.