### PR TITLE
Use Token::EOF instead of Option<Token>

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -100,7 +100,8 @@ impl Parser {
 
             if parser.peek_token() == Token::EOF {
                 break;
-            } else if expecting_statement_delimiter {
+            }
+            if expecting_statement_delimiter {
                 return parser.expected("end of statement", parser.peek_token());
             }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1342,7 +1342,7 @@ impl Parser {
     /// Parse a literal string
     pub fn parse_literal_string(&mut self) -> Result<String, ParserError> {
         match self.next_token() {
-            Token::SingleQuotedString(s) => Ok(s.clone()),
+            Token::SingleQuotedString(s) => Ok(s),
             unexpected => self.expected("literal string", unexpected),
         }
     }
@@ -1443,7 +1443,7 @@ impl Parser {
             //    character. When it sees such a <literal>, your DBMS will
             //    ignore the <separator> and treat the multiple strings as
             //    a single <literal>."
-            Token::SingleQuotedString(s) => Ok(Some(Ident::with_quote('\'', s.clone()))),
+            Token::SingleQuotedString(s) => Ok(Some(Ident::with_quote('\'', s))),
             not_an_ident => {
                 if after_as {
                     return self.expected("an identifier after AS", not_an_ident);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -26,6 +26,8 @@ use std::fmt;
 /// SQL Token enumeration
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
+    /// An end-of-file marker, not a real token
+    EOF,
     /// A keyword (like SELECT) or an optionally quoted SQL identifier
     Word(Word),
     /// An unsigned numeric literal
@@ -99,6 +101,7 @@ pub enum Token {
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Token::EOF => f.write_str("EOF"),
             Token::Word(ref w) => write!(f, "{}", w),
             Token::Number(ref n) => f.write_str(n),
             Token::Char(ref c) => write!(f, "{}", c),


### PR DESCRIPTION
This simplifies codes slightly, removing the need deal with the EOF case explicitly.

@Dandandan what do you think?