### PR TITLE
Add code example to see how to use serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,19 @@ edition = "2018"
 name = "sqlparser"
 path = "src/lib.rs"
 
+[features]
+# Enable JSON output in the `cli` example:
+json_example = ["serde_json", "serde"]
+
 [dependencies]
 bigdecimal = { version = "0.1.0", features = ["serde"], optional = true }
 log = "0.4.5"
 serde = { version = "1.0", features = ["derive"], optional = true }
+# serde_json is only used in examples/cli, but we have to put it outside
+# of dev-dependencies because of
+# https://github.com/rust-lang/cargo/issues/1596
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0"
 simple_logger = "1.0.1"
 matches = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ log = "0.4.5"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
+serde_json = "1.0"
 simple_logger = "1.0.1"
 matches = "0.1"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ This outputs
 AST: [Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [UnnamedExpr(Identifier("a")), UnnamedExpr(Identifier("b")), UnnamedExpr(Value(Long(123))), UnnamedExpr(Function(Function { name: ObjectName(["myfunc"]), args: [Identifier("b")], over: None, distinct: false }))], from: [TableWithJoins { relation: Table { name: ObjectName(["table_1"]), alias: None, args: [], with_hints: [] }, joins: [] }], selection: Some(BinaryOp { left: BinaryOp { left: Identifier("a"), op: Gt, right: Identifier("b") }, op: And, right: BinaryOp { left: Identifier("b"), op: Lt, right: Value(Long(100)) } }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier("a"), asc: Some(false) }, OrderByExpr { expr: Identifier("b"), asc: None }], limit: None, offset: None, fetch: None })]
 ```
 
+
+To simply try in CLI:
+```
+$ cargo run --example cli FILENAME.sql [--dialectname]
+
+[--dialectname]
+--ansi         => AnsiDialect {}
+--postgres     => PostgreSqlDialect {}
+--ms           => MsSqlDialect {}
+--generic | "" => GenericDialect {}
+```
+To serialize as JSON, just add `--feature serde`
+```
+$ cargo run --features serde --example cli FILENAME.sql [--dialectname]
+```
+
 ## SQL compliance
 
 SQL was first standardized in 1987, and revisions of the standard have been

--- a/README.md
+++ b/README.md
@@ -40,20 +40,10 @@ This outputs
 AST: [Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [UnnamedExpr(Identifier("a")), UnnamedExpr(Identifier("b")), UnnamedExpr(Value(Long(123))), UnnamedExpr(Function(Function { name: ObjectName(["myfunc"]), args: [Identifier("b")], over: None, distinct: false }))], from: [TableWithJoins { relation: Table { name: ObjectName(["table_1"]), alias: None, args: [], with_hints: [] }, joins: [] }], selection: Some(BinaryOp { left: BinaryOp { left: Identifier("a"), op: Gt, right: Identifier("b") }, op: And, right: BinaryOp { left: Identifier("b"), op: Lt, right: Value(Long(100)) } }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier("a"), asc: Some(false) }, OrderByExpr { expr: Identifier("b"), asc: None }], limit: None, offset: None, fetch: None })]
 ```
 
-
-To simply try in CLI:
+## Command line
+To parse a file and dump the results as JSON:
 ```
-$ cargo run --example cli FILENAME.sql [--dialectname]
-
-[--dialectname]
---ansi         => AnsiDialect {}
---postgres     => PostgreSqlDialect {}
---ms           => MsSqlDialect {}
---generic | "" => GenericDialect {}
-```
-To serialize as JSON, just add `--feature serde`
-```
-$ cargo run --features serde --example cli FILENAME.sql [--dialectname]
+$ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
 ```
 
 ## SQL compliance

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -66,7 +66,8 @@ $ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
             );
 
             if cfg!(feature = "json_example") {
-                #[cfg(feature = "json_example")] {
+                #[cfg(feature = "json_example")]
+                {
                     let serialized = serde_json::to_string_pretty(&statements).unwrap();
                     println!("Serialized as JSON:\n{}", serialized);
                 }

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -23,8 +23,16 @@ fn main() {
     simple_logger::init().unwrap();
 
     let filename = std::env::args().nth(1).expect(
-        "No arguments provided!\n\n\
-         Usage: cargo run --example cli FILENAME.sql [--dialectname]",
+        r#"
+No arguments provided!
+
+Usage:
+$ cargo run --example cli FILENAME.sql [--dialectname]
+
+To serialize as JSON:
+$ cargo run --feature serde --example cli FILENAME.sql [--dialectname]
+
+"#,
     );
 
     let dialect: Box<dyn Dialect> = match std::env::args().nth(2).unwrap_or_default().as_ref() {
@@ -56,7 +64,18 @@ fn main() {
                     .collect::<Vec<_>>()
                     .join("\n")
             );
-            println!("Parse results:\n{:#?}", statements);
+
+            if cfg!(not(feature = "serde")) {
+                println!("Parse results:\n{:#?}", statements);
+            } else {
+                #[cfg(feature = "serde")]
+                {
+                    let serialized = serde_json::to_string_pretty(&statements).unwrap();
+
+                    println!("Serialized as JSON:\n{}", serialized);
+                }
+            }
+
             std::process::exit(0);
         }
         Err(e) => {

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -29,8 +29,8 @@ No arguments provided!
 Usage:
 $ cargo run --example cli FILENAME.sql [--dialectname]
 
-To serialize as JSON:
-$ cargo run --feature serde --example cli FILENAME.sql [--dialectname]
+To print the parse results as JSON:
+$ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
 
 "#,
     );
@@ -65,15 +65,13 @@ $ cargo run --feature serde --example cli FILENAME.sql [--dialectname]
                     .join("\n")
             );
 
-            if cfg!(not(feature = "serde")) {
-                println!("Parse results:\n{:#?}", statements);
-            } else {
-                #[cfg(feature = "serde")]
-                {
+            if cfg!(feature = "json_example") {
+                #[cfg(feature = "json_example")] {
                     let serialized = serde_json::to_string_pretty(&statements).unwrap();
-
                     println!("Serialized as JSON:\n{}", serialized);
                 }
+            } else {
+                println!("Parse results:\n{:#?}", statements);
             }
 
             std::process::exit(0);


### PR DESCRIPTION
Related to PR: https://github.com/andygrove/sqlparser-rs/pull/196

Because `serde` is an optional dependency, if I modify existing example codes, then it may make other new comers feel bothersome.
So I added new code example named `examples/serde.rs`.
@nickolay How do you think of this?