### PR TITLE
Add without id support for SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Check https://github.com/andygrove/sqlparser-rs/commits/master for undocumented 
 ### Changed
 
 ### Added
+- Support SQLite's `CREATE TABLE (...) WITHOUT ROWID` (#208) - thanks @mashuai!
 
 ### Fixed
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -482,6 +482,7 @@ pub enum Statement {
         file_format: Option<FileFormat>,
         location: Option<String>,
         query: Option<Box<Query>>,
+        without_rowid: Option<bool>,
     },
     /// CREATE INDEX
     CreateIndex {
@@ -647,6 +648,7 @@ impl fmt::Display for Statement {
                 file_format,
                 location,
                 query,
+                without_rowid,
             } => {
                 // We want to allow the following options
                 // Empty column list, allowed by PostgreSQL:
@@ -686,6 +688,11 @@ impl fmt::Display for Statement {
                 }
                 if let Some(query) = query {
                     write!(f, " AS {}", query)?;
+                }
+                if let Some(without_rowid) = *without_rowid {
+                    if without_rowid {
+                        write!(f, "WITHOUT ROWID")?;
+                    }
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -674,6 +674,10 @@ impl fmt::Display for Statement {
                     // PostgreSQL allows `CREATE TABLE t ();`, but requires empty parens
                     write!(f, " ()")?;
                 }
+                // Only for SQLite
+                if *without_rowid {
+                    write!(f, " WITHOUT ROWID")?;
+                }
 
                 if *external {
                     write!(
@@ -688,9 +692,6 @@ impl fmt::Display for Statement {
                 }
                 if let Some(query) = query {
                     write!(f, " AS {}", query)?;
-                }
-                if *without_rowid {
-                    write!(f, " WITHOUT ROWID")?;
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -482,7 +482,7 @@ pub enum Statement {
         file_format: Option<FileFormat>,
         location: Option<String>,
         query: Option<Box<Query>>,
-        without_rowid: Option<bool>,
+        without_rowid: bool,
     },
     /// CREATE INDEX
     CreateIndex {
@@ -689,10 +689,8 @@ impl fmt::Display for Statement {
                 if let Some(query) = query {
                     write!(f, " AS {}", query)?;
                 }
-                if let Some(without_rowid) = *without_rowid {
-                    if without_rowid {
-                        write!(f, " WITHOUT ROWID")?;
-                    }
+                if *without_rowid {
+                    write!(f, " WITHOUT ROWID")?;
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -691,7 +691,7 @@ impl fmt::Display for Statement {
                 }
                 if let Some(without_rowid) = *without_rowid {
                     if without_rowid {
-                        write!(f, "WITHOUT ROWID")?;
+                        write!(f, " WITHOUT ROWID")?;
                     }
                 }
                 Ok(())

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -351,6 +351,7 @@ define_keywords!(
     ROLLBACK,
     ROLLUP,
     ROW,
+    ROWID,
     ROWS,
     ROW_NUMBER,
     SAVEPOINT,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1010,6 +1010,7 @@ impl Parser {
 
         self.expect_keyword(Keyword::LOCATION)?;
         let location = self.parse_literal_string()?;
+        let without_rowid = self.parse_keywords(&[Keyword::WITHOUT, Keyword::ROWID]);
 
         Ok(Statement::CreateTable {
             name: table_name,
@@ -1021,6 +1022,7 @@ impl Parser {
             file_format: Some(file_format),
             location: Some(location),
             query: None,
+            without_rowid: Some(without_rowid),
         })
     }
 
@@ -1120,6 +1122,8 @@ impl Parser {
             None
         };
 
+        // SQLite supports `WITHOUT ROWID` at the end of `CREATE TABLE`
+        let without_rowid = self.parse_keywords(&[Keyword::WITHOUT, Keyword::ROWID]);
         Ok(Statement::CreateTable {
             name: table_name,
             columns,
@@ -1130,6 +1134,7 @@ impl Parser {
             file_format: None,
             location: None,
             query,
+            without_rowid: Some(without_rowid),
         })
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1010,7 +1010,6 @@ impl Parser {
 
         self.expect_keyword(Keyword::LOCATION)?;
         let location = self.parse_literal_string()?;
-        let without_rowid = self.parse_keywords(&[Keyword::WITHOUT, Keyword::ROWID]);
 
         Ok(Statement::CreateTable {
             name: table_name,
@@ -1022,7 +1021,7 @@ impl Parser {
             file_format: Some(file_format),
             location: Some(location),
             query: None,
-            without_rowid: Some(without_rowid),
+            without_rowid: false,
         })
     }
 
@@ -1112,6 +1111,9 @@ impl Parser {
         // parse optional column list (schema)
         let (columns, constraints) = self.parse_columns()?;
 
+        // SQLite supports `WITHOUT ROWID` at the end of `CREATE TABLE`
+        let without_rowid = self.parse_keywords(&[Keyword::WITHOUT, Keyword::ROWID]);
+
         // PostgreSQL supports `WITH ( options )`, before `AS`
         let with_options = self.parse_with_options()?;
 
@@ -1122,8 +1124,6 @@ impl Parser {
             None
         };
 
-        // SQLite supports `WITHOUT ROWID` at the end of `CREATE TABLE`
-        let without_rowid = self.parse_keywords(&[Keyword::WITHOUT, Keyword::ROWID]);
         Ok(Statement::CreateTable {
             name: table_name,
             columns,
@@ -1134,7 +1134,7 @@ impl Parser {
             file_format: None,
             location: None,
             query,
-            without_rowid: Some(without_rowid),
+            without_rowid,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1044,8 +1044,7 @@ fn parse_create_table() {
             external: false,
             file_format: None,
             location: None,
-            query: _query,
-            without_rowid,
+            ..
         } => {
             assert_eq!("uk_cities", name.to_string());
             assert_eq!(
@@ -1134,7 +1133,6 @@ fn parse_create_table() {
             );
             assert!(constraints.is_empty());
             assert_eq!(with_options, vec![]);
-            assert_eq!(without_rowid, Some(true));
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1023,7 +1023,7 @@ fn parse_create_table() {
                constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0),
                ref INT REFERENCES othertable (a, b),\
                ref2 INT references othertable2 on delete cascade on update no action\
-               )";
+               )WITHOUT ROWID";
     let ast = one_statement_parses_to(
         sql,
         "CREATE TABLE uk_cities (\
@@ -1032,7 +1032,7 @@ fn parse_create_table() {
          lng DOUBLE, \
          constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), \
          ref INT REFERENCES othertable (a, b), \
-         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION)",
+         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION)WITHOUT ROWID",
     );
     match ast {
         Statement::CreateTable {
@@ -1045,6 +1045,7 @@ fn parse_create_table() {
             file_format: None,
             location: None,
             query: _query,
+            without_rowid,
         } => {
             assert_eq!("uk_cities", name.to_string());
             assert_eq!(
@@ -1133,6 +1134,7 @@ fn parse_create_table() {
             );
             assert!(constraints.is_empty());
             assert_eq!(with_options, vec![]);
+            assert_eq!(without_rowid, Some(true));
         }
         _ => unreachable!(),
     }
@@ -1277,6 +1279,7 @@ fn parse_create_external_table() {
             file_format,
             location,
             query: _query,
+            without_rowid: _,
         } => {
             assert_eq!("uk_cities", name.to_string());
             assert_eq!(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1023,7 +1023,7 @@ fn parse_create_table() {
                constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0),
                ref INT REFERENCES othertable (a, b),\
                ref2 INT references othertable2 on delete cascade on update no action\
-               ) WITHOUT ROWID";
+               )";
     let ast = one_statement_parses_to(
         sql,
         "CREATE TABLE uk_cities (\
@@ -1032,7 +1032,7 @@ fn parse_create_table() {
          lng DOUBLE, \
          constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), \
          ref INT REFERENCES othertable (a, b), \
-         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION) WITHOUT ROWID",
+         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION)",
     );
     match ast {
         Statement::CreateTable {
@@ -1276,8 +1276,7 @@ fn parse_create_external_table() {
             external,
             file_format,
             location,
-            query: _query,
-            without_rowid: _,
+            ..
         } => {
             assert_eq!("uk_cities", name.to_string());
             assert_eq!(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1023,7 +1023,7 @@ fn parse_create_table() {
                constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0),
                ref INT REFERENCES othertable (a, b),\
                ref2 INT references othertable2 on delete cascade on update no action\
-               )WITHOUT ROWID";
+               ) WITHOUT ROWID";
     let ast = one_statement_parses_to(
         sql,
         "CREATE TABLE uk_cities (\
@@ -1032,7 +1032,7 @@ fn parse_create_table() {
          lng DOUBLE, \
          constrained INT NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), \
          ref INT REFERENCES othertable (a, b), \
-         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION)WITHOUT ROWID",
+         ref2 INT REFERENCES othertable2 ON DELETE CASCADE ON UPDATE NO ACTION) WITHOUT ROWID",
     );
     match ast {
         Statement::CreateTable {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -43,8 +43,7 @@ fn parse_create_table_with_defaults() {
             external: false,
             file_format: None,
             location: None,
-            query: _query,
-            without_rowid: _,
+            ..
         } => {
             assert_eq!("public.customer", name.to_string());
             assert_eq!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -44,6 +44,7 @@ fn parse_create_table_with_defaults() {
             file_format: None,
             location: None,
             query: _query,
+            without_rowid: _,
         } => {
             assert_eq!("public.customer", name.to_string());
             assert_eq!(

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -20,8 +20,8 @@ use sqlparser::test_utils::*;
 
 #[test]
 fn parse_create_table_without_rowid() {
-    let sql = "CREATE TABLE t(a INT) WITHOUT ROWID";
-    match sqlite_and_generic().one_statement_parses_to(sql, "") {
+    let sql = "CREATE TABLE t (a INT) WITHOUT ROWID";
+    match sqlite_and_generic().verified_stmt(sql) {
         Statement::CreateTable {
             name,
             without_rowid: true,

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -28,14 +28,9 @@ fn parse_create_table() {
         Statement::CreateTable {
             name,
             columns,
-            constraints,
-            with_options: _with_options,
-            if_not_exists: false,
-            external: false,
-            file_format: None,
-            location: None,
-            query: _query,
             without_rowid: true,
+            constraints,
+            ..
         } => {
             assert_eq!("groups", name.to_string());
             assert_eq!(

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 #![warn(clippy::all)]
-//! Test SQL syntax specific to PostgreSQL. The parser based on the
+//! Test SQL syntax specific to SQLite. The parser based on the
 //! generic dialect is also tested (on the inputs it can handle).
 
 use sqlparser::ast::*;
@@ -19,51 +19,23 @@ use sqlparser::dialect::GenericDialect;
 use sqlparser::test_utils::*;
 
 #[test]
-fn parse_create_table() {
-    let sql = "CREATE TABLE groups (
-                       group_id INTEGER NOT NULL,
-                       name TEXT NOT NULL
-                    ) WITHOUT ROWID";
-    match sqlite().one_statement_parses_to(sql, "") {
+fn parse_create_table_without_rowid() {
+    let sql = "CREATE TABLE t(a INT) WITHOUT ROWID";
+    match sqlite_and_generic().one_statement_parses_to(sql, "") {
         Statement::CreateTable {
             name,
-            columns,
             without_rowid: true,
-            constraints,
             ..
         } => {
-            assert_eq!("groups", name.to_string());
-            assert_eq!(
-                columns,
-                vec![
-                    ColumnDef {
-                        name: "group_id".into(),
-                        data_type: DataType::Int,
-                        collation: None,
-                        options: vec![ColumnOptionDef {
-                            name: None,
-                            option: ColumnOption::NotNull,
-                        }],
-                    },
-                    ColumnDef {
-                        name: "name".into(),
-                        data_type: DataType::Text,
-                        collation: None,
-                        options: vec![ColumnOptionDef {
-                            name: None,
-                            option: ColumnOption::NotNull,
-                        }],
-                    },
-                ]
-            );
-            assert!(constraints.is_empty());
+            assert_eq!("t", name.to_string());
         }
         _ => unreachable!(),
     }
 }
 
-fn sqlite() -> TestedDialects {
+fn sqlite_and_generic() -> TestedDialects {
     TestedDialects {
+        // we don't have a separate SQLite dialect, so test only the generic dialect for now
         dialects: vec![Box::new(GenericDialect {})],
     }
 }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![warn(clippy::all)]
+//! Test SQL syntax specific to PostgreSQL. The parser based on the
+//! generic dialect is also tested (on the inputs it can handle).
+
+use sqlparser::ast::*;
+use sqlparser::dialect::GenericDialect;
+use sqlparser::test_utils::*;
+
+#[test]
+fn parse_create_table() {
+    let sql = "CREATE TABLE groups (
+                       group_id INTEGER NOT NULL,
+                       name TEXT NOT NULL
+                    ) WITHOUT ROWID";
+    match sqlite().one_statement_parses_to(sql, "") {
+        Statement::CreateTable {
+            name,
+            columns,
+            constraints,
+            with_options: _with_options,
+            if_not_exists: false,
+            external: false,
+            file_format: None,
+            location: None,
+            query: _query,
+            without_rowid: true,
+        } => {
+            assert_eq!("groups", name.to_string());
+            assert_eq!(
+                columns,
+                vec![
+                    ColumnDef {
+                        name: "group_id".into(),
+                        data_type: DataType::Int,
+                        collation: None,
+                        options: vec![ColumnOptionDef {
+                            name: None,
+                            option: ColumnOption::NotNull,
+                        }],
+                    },
+                    ColumnDef {
+                        name: "name".into(),
+                        data_type: DataType::Text,
+                        collation: None,
+                        options: vec![ColumnOptionDef {
+                            name: None,
+                            option: ColumnOption::NotNull,
+                        }],
+                    },
+                ]
+            );
+            assert!(constraints.is_empty());
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn sqlite() -> TestedDialects {
+    TestedDialects {
+        dialects: vec![Box::new(GenericDialect {})],
+    }
+}


### PR DESCRIPTION
SQLite supports `WITHOUT ROWID` at the end of `CREATE TABLE` [SQLite Create Table](https://sqlite.org/lang_createtable.html)